### PR TITLE
fix: issue with search box

### DIFF
--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -31,7 +31,7 @@ func (m model) handlesKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.focus == focusSearch {
-		if msg.String() == "enter" {
+		if keyMatches(key, api.AppConfig.Keybinds.Navigation.Select) {
 			return enter(m)
 		}
 		return typeInput(m, msg)


### PR DESCRIPTION
## Problem

When trying to search for an album/artist/etc. I was able to type down but hitting enter won't do anything.

### System were the issue occurred

macOs 26.2, using iterm2 running SubTUI via source, and also reproduced with the latest released binary 

## Solution

Capture the `enter` keystroke and run the `enter` function in that case.