### PR TITLE
Fix module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/MattiaPun/SubTUI
+module github.com/MattiaPun/SubTUI/v2
 
 go 1.25.4
 


### PR DESCRIPTION
Fix the module path in go.mod for v2.
Otherwise, go install attempts to install the latest v0 or v1 release (v1.8.4 in case of SubTUI).

Thanks to @clausecker for helping me out with tracking this down.