### PR TITLE
Update README for installation instruction on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ You can download pre-compiled binaries for Linux and macOS directly from the [Re
 
 You can install SubTUI directly from the AUR: `yay -S subtui-git`
 
+### FreeBSD
+
+You can install SubTUI directly from the pkg repository: `pkg install subtui`
+
 ### GoLang Toolchain
 
 You can install SubTUI directly using GoLang: `go install github.com/MattiaPun/SubTUI@latest`


### PR DESCRIPTION
FreeBSD now has a port of [SubTUI](https://freshports.org/audio/subtui) for easy installation.