### PR TITLE
Add FreeBSD support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,7 @@ builds:
     goos:
       - linux
       - darwin
+      - freebsd
     goarch:
       - amd64
       - arm64

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ You can download pre-compiled binaries for Linux and macOS directly from the [Re
 
 You can install SubTUI directly from the AUR: `yay -S subtui-git`
 
+### FreeBSD
+
+You can install SubTUI directly via `pkg`: `pkg install subtui`
+Note that this will automatically install the `mpv` dependency
+
 ### GoLang Toolchain
 
 You can install SubTUI directly using GoLang: `go install github.com/MattiaPun/SubTUI@latest`

--- a/internal/integration/media_dbus.go
+++ b/internal/integration/media_dbus.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux || freebsd
 
 package integration
 

--- a/internal/integration/media_dbus_methods.go
+++ b/internal/integration/media_dbus_methods.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux || freebsd
 
 package integration
 

--- a/internal/integration/media_dbus_props.go
+++ b/internal/integration/media_dbus_props.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux || freebsd
 
 package integration
 


### PR DESCRIPTION
This introduces FreeBSD support. Files with a Linux specific filename have been renamed to dbus instead as the corresponding code is dbus specific - not Linux specific.

Fixes #32