### PR TITLE
feat: add shuffle flag with auto-play functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ go build .
 ./subtui
 ```
 
+## Command-Line Flags
+
+SubTUI supports the following command-line flags:
+
+* `--debug`: Enable debug logging to `subtui.log`
+* `--shuffle`: Start with random albums, shuffle them, and automatically begin playback
+* `-v`: Print version and exit
+
+Example usage:
+```bash
+# Start with random shuffled music and begin playing immediately
+./subtui --shuffle
+
+# Enable debug logging
+./subtui --debug
+```
+
 ## Configuration
 On the first launch, SubTUI will generate a default configuration file at: `~/.config/subtui/config.toml`.
  **Security Note**: Your credentials are stored in plaintext

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -51,6 +51,7 @@ func InitPlayer() error {
 		"--gapless-audio=yes",
 		"--prefetch-playlist=yes",
 		"--replaygain=" + replayGain,
+		"--load-scripts=no", // Disable MPV's MPRIS to avoid duplicate sessions
 	}
 
 	mpvCmd = exec.Command("mpv", args...)

--- a/internal/ui/init.go
+++ b/internal/ui/init.go
@@ -6,7 +6,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func InitialModel() model {
+func InitialModel(shuffleMode bool) model {
 	ti := textinput.New()
 	ti.Placeholder = "Search songs..."
 	ti.Focus()
@@ -18,6 +18,13 @@ func InitialModel() model {
 		startMode = viewLogin
 	}
 
+	albumListType := ""
+	displayMode := displaySongs
+	if shuffleMode {
+		albumListType = "random"
+		displayMode = displayAlbums
+	}
+
 	return model{
 		textInput:        ti,
 		songs:            []api.Song{},
@@ -27,7 +34,7 @@ func InitialModel() model {
 		cursorPopup:      0,
 		viewMode:         startMode,
 		filterMode:       filterSongs,
-		displayMode:      displaySongs,
+		displayMode:      displayMode,
 		starredMap:       make(map[string]bool),
 		lastPlayedSongID: "",
 		loginInputs:      initialLoginInputs(),
@@ -37,6 +44,9 @@ func InitialModel() model {
 		helpModel:        NewHelpModel(),
 		discordRPC:       api.AppConfig.App.DiscordRPC,
 		notify:           api.AppConfig.App.Notifications,
+		albumListType:    albumListType,
+		startupRandom:    shuffleMode,
+		startupShuffle:   shuffleMode,
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -75,6 +75,11 @@ type model struct {
 	albumListType   string
 	pageOffset      int
 	pageHasMore     bool
+
+	// Startup Flags
+	startupRandom   bool
+	startupShuffle  bool
+	autoPlayPending bool
 }
 
 type HelpModel struct {

--- a/internal/ui/update_messages.go
+++ b/internal/ui/update_messages.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/MattiaPun/SubTUI/v2/internal/api"
 	"github.com/MattiaPun/SubTUI/v2/internal/integration"
@@ -65,12 +67,20 @@ func (m model) handleLoginResult(msg loginResultMsg) (tea.Model, tea.Cmd) {
 	m.focus = focusMain
 	m.loginErr = ""
 
-	return m, tea.Batch(
+	// Build command batch
+	cmds := []tea.Cmd{
 		syncPlayerCmd(),
 		getPlaylists(),
 		getPlayQueue(),
 		getStarredCmd(),
-	)
+	}
+
+	// If shuffle mode is enabled, fetch random albums after login
+	if m.albumListType == "random" {
+		cmds = append(cmds, getAlbumList("random", 0))
+	}
+
+	return m, tea.Batch(cmds...)
 }
 
 func (m model) handlePlaylistResult(msg playlistResultMsg) (tea.Model, tea.Cmd) {
@@ -219,6 +229,30 @@ func (m model) handleSongResult(msg songsResultMsg) (tea.Model, tea.Cmd) {
 
 	m.pageHasMore = (len(msg.songs) == 150)
 
+	// Handle auto-play (from --random flag)
+	if m.autoPlayPending && len(m.songs) > 0 {
+		m.autoPlayPending = false
+
+		// Apply shuffle if requested
+		if m.startupShuffle {
+			m.startupShuffle = false
+			newQueue := make([]api.Song, len(m.songs))
+			copy(newQueue, m.songs)
+			m.queue = newQueue
+
+			// Shuffle the queue
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			r.Shuffle(len(m.queue), func(i, j int) {
+				m.queue[i], m.queue[j] = m.queue[j], m.queue[i]
+			})
+
+			return m, m.playQueueIndex(0, false)
+		}
+
+		// Play normally without shuffle
+		return m, m.setQueue(0)
+	}
+
 	return m, nil
 }
 
@@ -233,6 +267,16 @@ func (m model) handleAlbumResult(msg albumsResultMsg) (tea.Model, tea.Cmd) {
 		m.albums = msg.albums
 		m.cursorMain = 0
 		m.mainOffset = 0
+	}
+
+	// Handle startup random mode: automatically play first album
+	if m.startupRandom && len(m.albums) > 0 {
+		m.startupRandom = false // Only do this once
+		m.autoPlayPending = true
+		selectedAlbum := m.albums[0]
+		m.loading = true
+		m.displayMode = displaySongs
+		return m, getAlbumSongs(selectedAlbum.ID)
 	}
 
 	return m, nil

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func main() {
 	// Debug flag
 	debug := flag.Bool("debug", false, "Enable debug logging to subtui.log")
 	showVersion := flag.Bool("v", false, "Print version and exit")
+	shuffleMode := flag.Bool("shuffle", false, "Start with random albums, shuffle them, and begin playback")
 	flag.Parse()
 
 	// Check for version
@@ -66,7 +67,7 @@ func main() {
 	defer player.ShutdownPlayer()
 
 	// Init TUI
-	p := tea.NewProgram(ui.InitialModel(), tea.WithAltScreen())
+	p := tea.NewProgram(ui.InitialModel(*shuffleMode), tea.WithAltScreen())
 
 	// Start background services
 	instance := integration.Init(p)


### PR DESCRIPTION
## Summary
- Add `--shuffle` command-line flag for auto-play with shuffle mode
- Disable MPV's MPRIS script to avoid duplicate media player sessions
- Add command-line flags documentation to README

## Changes
- **New Feature**: `--shuffle` flag starts with random albums, shuffles them, and automatically begins playback
- **Bug Fix**: Disable MPV's `--load-scripts` to prevent duplicate MPRIS sessions
- **Documentation**: Add Command-Line Flags section to README with examples

## Usage Example
```bash
# Start with random shuffled music and begin playing immediately
./subtui --shuffle

# Enable debug logging
./subtui --debug
```

## Test Plan
- [x] Compile and run with `--shuffle` flag
- [x] Verify random albums are fetched
- [x] Verify playback starts automatically
- [x] Verify shuffle is applied to queue
- [x] Verify MPV MPRIS conflicts are resolved

🤖 Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>