### PR TITLE
feat(queue): add configurable song filters

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -23,6 +23,7 @@ var AppServerConfig ServerConfig
 type Config struct {
 	App      App      `toml:"app"`
 	Theme    Theme    `toml:"theme"`
+	Filters  Filters  `toml:"filters"`
 	Keybinds Keybinds `toml:"keybinds"`
 }
 
@@ -52,6 +53,19 @@ type Theme struct {
 	Subtle    []string `toml:"subtle"`
 	Highlight []string `toml:"highlight"`
 	Special   []string `toml:"special"`
+}
+
+type Filters struct {
+	Titles           []string `toml:"titles"`
+	Artists          []string `toml:"artists"`
+	AlbumArtists     []string `toml:"album_artists"`
+	MinDuration      int      `toml:"min_duration"`
+	Genres           []string `toml:"genres"`
+	Notes            []string `toml:"notes"`
+	Paths            []string `toml:"paths"`
+	MaxPlayCount     int      `toml:"max_play_count"`
+	ExcludeFavorites bool     `toml:"exclude_favorites"`
+	MaxRating        int      `toml:"max_rating"`
 }
 
 type Keybinds struct {

--- a/internal/api/config.toml
+++ b/internal/api/config.toml
@@ -10,6 +10,18 @@ subtle    = ["#D9DCCF", "#6B6B6BFF"]
 highlight = ["#874BFD", "#7D56F4"]
 special   = ["#43BF6D", "#73F59F"]
 
+[filters]
+titles = [] # Exclude songs with titles containing these strings
+artists = [] # Exclude songs by these artists
+album_artists = [] # Exclude songs by these album artists
+min_duration = 0 # Exclude songs with a duration shorter than or equal to this length (in seconds). 0 to disable.
+genres = [] # Exclude songs belonging to these genres
+notes = [] # Exclude songs with comments/notes containing these strings
+paths = [] # Exclude songs whose file path contains these strings
+max_play_count = 0 # Exclude songs with a play count less than or equal to this number. 0 to disable.
+exclude_favorites = false # Set to true to exclude songs that are marked as a favorite/starred
+max_rating = 0 # Exclude songs with a rating less than or equal to this number (1-5). 0 to disable.
+
 [keybinds]
   [keybinds.global]
   cycle_focus_next = ["tab"]

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -70,14 +70,20 @@ type Album struct {
 }
 
 type Song struct {
-	ID       string `json:"id"`
-	Title    string `json:"title"`
-	Artist   string `json:"artist"`
-	ArtistID string `json:"artistId"`
-	Album    string `json:"album"`
-	AlbumID  string `json:"albumId"`
-	Duration int    `json:"duration"`
-	Rating   int    `json:"userRating"`
+	ID           string   `json:"id"`
+	Title        string   `json:"title"`
+	Artist       string   `json:"artist"`
+	ArtistID     string   `json:"artistId"`
+	AlbumArtists []Artist `json:"albumArtists"`
+	Album        string   `json:"album"`
+	AlbumID      string   `json:"albumId"`
+	Duration     int      `json:"duration"`
+	Rating       int      `json:"userRating"`
+	Genre        string   `json:"genre"`
+	Year         int      `json:"year"`
+	Note         string   `json:"comment"`
+	Path         string   `json:"path"`
+	PlayCount    int      `json:"playCount"`
 }
 
 type Playlist struct {


### PR DESCRIPTION
Introduces a new `[filters]` section in `config.toml` to exclude songs from the playback queue. 
Songs can be filtered by **title**, **artist**, **album artist**, **duration**, **genre**, **path**, **notes**, **play count**, **favorite status**, and **user rating**.

Resolves #44 