### PR TITLE
feat(ui): close pop-ups on back action

### DIFF
--- a/internal/api/config.toml
+++ b/internal/api/config.toml
@@ -27,7 +27,7 @@ max_rating = 0 # Exclude songs with a rating less than or equal to this number (
   [keybinds.global]
   cycle_focus_next = ["tab"]
   cycle_focus_prev = ["shift+tab"]
-  back             = ["backspace"]
+  back             = ["backspace", "esc"]
   help             = ["?"]
   quit             = ["q"]
   hard_quit        = ["ctrl+c"]

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -45,6 +45,10 @@ func (m model) handlesKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return typeInput(m, msg)
 	}
 
+	if keyMatches(key, api.AppConfig.Keybinds.Global.Back) {
+		return goBack(m)
+	}
+
 	if m.showPlaylists {
 		return playlistsMenu(key, m)
 	}
@@ -79,9 +83,6 @@ func (m model) handlesKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// GLOBAL KEYBINDS
-	if keyMatches(key, api.AppConfig.Keybinds.Global.Back) {
-		return goBack(m)
-	}
 
 	if keyMatches(key, api.AppConfig.Keybinds.Global.Quit) {
 		return quit(m, msg)
@@ -399,6 +400,14 @@ func playShuffeled(m model) (tea.Model, tea.Cmd) {
 }
 
 func goBack(m model) (tea.Model, tea.Cmd) {
+	if m.showHelp || m.showPlaylists || m.showRating {
+		m.showHelp = false
+		m.showPlaylists = false
+		m.showRating = false
+
+		return m, nil
+	}
+
 	if m.viewMode == viewQueue {
 		return toggleQueue(m), nil
 	}


### PR DESCRIPTION
Added escape as a second default keybind for the back action
Close pop-ups (add rating, add to playlist, ...) when executing the back action

Resolves #53 