### PR TITLE
feat(ui): added customizable columns for song views

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Theme    Theme    `toml:"theme"`
 	Filters  Filters  `toml:"filters"`
 	Keybinds Keybinds `toml:"keybinds"`
+	Columns  Columns  `toml:"columns"`
 }
 
 type ServerConfig struct {
@@ -66,6 +67,18 @@ type Filters struct {
 	MaxPlayCount     int      `toml:"max_play_count"`
 	ExcludeFavorites bool     `toml:"exclude_favorites"`
 	MaxRating        int      `toml:"max_rating"`
+}
+
+type Columns struct {
+	ShowTrackNumber bool `toml:"track_number"`
+	ShowTitle       bool `toml:"title"`
+	ShowArtist      bool `toml:"artist"`
+	ShowAlbum       bool `toml:"album"`
+	ShowYear        bool `toml:"year"`
+	ShowGenre       bool `toml:"genre"`
+	ShowRating      bool `toml:"rating"`
+	ShowPlayCount   bool `toml:"play_count"`
+	ShowDuration    bool `toml:"duration"`
 }
 
 type Keybinds struct {

--- a/internal/api/config.toml
+++ b/internal/api/config.toml
@@ -23,6 +23,17 @@ max_play_count = 0 # Exclude songs with a play count less than or equal to this 
 exclude_favorites = false # Set to true to exclude songs that are marked as a favorite/starred
 max_rating = 0 # Exclude songs with a rating less than or equal to this number (1-5). 0 to disable.
 
+[columns]
+track_number = false
+title = true
+artist = true
+album = true
+year = false
+genre = false
+rating = false
+play_count = false
+duration = true
+
 [keybinds]
   [keybinds.global]
   cycle_focus_next = ["tab"]

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -84,6 +84,8 @@ type Song struct {
 	Note         string   `json:"comment"`
 	Path         string   `json:"path"`
 	PlayCount    int      `json:"playCount"`
+	TrackNumber  int      `json:"track"`
+	DiscNumber   int      `json:"discNumber"`
 	Filtered     bool
 }
 


### PR DESCRIPTION
Added customizable columns for the main song and queue views. Users can now toggle the visibility of specific fields directly in their `config.toml` to tailor the interface to their needs.

**New Config Toggles:**
* Track & Disc Number
* Title, Artist, Album, Year, Genre
* Rating & Play Count
* Duration

Resolves #46 