### PR TITLE
fix: guard queue index access when queue is empty

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -418,7 +418,7 @@ func mainSongsContent(m model, mainWidth int, mainHeight int) string {
 		}
 
 		// Display current playing song
-		if song.ID == m.queue[m.queueIndex].ID {
+		if len(m.queue) > 0 && song.ID == m.queue[m.queueIndex].ID {
 			style = style.Foreground(Theme.Special)
 		}
 


### PR DESCRIPTION
Accessing m.queue[m.queueIndex] panics at startup when the queue is empty (nothing has been played yet). Add a len check before the access.