### PR TITLE
feat(config): use -c flag for custom configdir or SUBTUI_CONFIG env variable

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
+var ConfigDir string
+
 //go:embed config.toml
 var defaultConfig []byte
 var AppConfig Config
@@ -157,15 +159,6 @@ type OtherKeybinds struct {
 	CreateShareLink     []string `toml:"create_share_link"`
 }
 
-func GetConfigPath(configName string) string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-
-	return filepath.Join(home, ".config", "subtui", configName)
-}
-
 func createDefaultConfig(path string, content []byte, label string, permissions os.FileMode) error {
 	// Create config dir
 	dir := filepath.Dir(path)
@@ -183,13 +176,15 @@ func createDefaultConfig(path string, content []byte, label string, permissions 
 	return nil
 }
 
-func LoadConfig() error {
+func LoadConfig(configDir string) error {
+	ConfigDir = configDir
+
 	// Get config paths
-	configPath := GetConfigPath("config.toml")
+	configPath := filepath.Join(ConfigDir, "config.toml")
 	if configPath == "" {
 		return fmt.Errorf("could not determine config path")
 	}
-	credentialsConfigPath := GetConfigPath("credentials.toml")
+	credentialsConfigPath := filepath.Join(ConfigDir, "credentials.toml")
 	if credentialsConfigPath == "" {
 		return fmt.Errorf("could not determine server config path")
 	}

--- a/internal/ui/cmds_api.go
+++ b/internal/ui/cmds_api.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"bytes"
 	"image/jpeg"
+	"path/filepath"
 
 	"github.com/MattiaPun/SubTUI/v2/internal/api"
 	tea "github.com/charmbracelet/bubbletea"
@@ -10,7 +11,7 @@ import (
 
 func attemptLoginCmd() tea.Cmd {
 	return func() tea.Msg {
-		if err := api.SaveConfig(api.GetConfigPath("credentials.toml"), api.AppServerConfig, 0600); err != nil {
+		if err := api.SaveConfig(filepath.Join(api.ConfigDir, "credentials.toml"), api.AppServerConfig, 0600); err != nil {
 			return loginResultMsg{err: err}
 		}
 

--- a/main.go
+++ b/main.go
@@ -22,7 +22,14 @@ var (
 )
 
 func main() {
+	// Precedence: cli flag > ENV variable > default
+	defaultConfig := "~/.config/subtui"
+	if envConfig := os.Getenv("SUBTUI_CONFIG"); envConfig != "" {
+		defaultConfig = envConfig
+	}
+
 	// Debug flag
+	configPath := flag.String("c", defaultConfig, "Custom config folder path")
 	debug := flag.Bool("debug", false, "Enable debug logging to subtui.log")
 	showVersion := flag.Bool("v", false, "Print version and exit")
 	flag.Parse()
@@ -53,7 +60,7 @@ func main() {
 	}
 
 	// Load Config
-	if err := api.LoadConfig(); err != nil {
+	if err := api.LoadConfig(*configPath); err != nil {
 		fmt.Printf("Fatal error loading config: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Use the `-c` flag with a custom directory to use a different config directory or set the `SUBTUI_CONFIG`.
Precedence: cli flag > ENV variable > default

Resolves #66 