### PR TITLE
fix(typo): shuffeled -> shuffled

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -136,7 +136,7 @@ type NavigationKeybinds struct {
 	Top          []string `toml:"top"`
 	Bottom       []string `toml:"bottom"`
 	Select       []string `toml:"select"`
-	PlayShuffled []string `toml:"play_shuffeled"`
+	PlayShuffled []string `toml:"play_shuffled"`
 }
 
 type SearchKeybinds struct {

--- a/internal/api/config.toml
+++ b/internal/api/config.toml
@@ -7,7 +7,7 @@ mouse_support         = false
 [theme]
 display_album_art  = true
 # Format: ['Light Color', 'Dark Color']
-subtle             = ['#D9DCCF', '#6B6B6BFF'] 
+subtle             = ['#D9DCCF', '#6B6B6BFF']
 highlight          = ['#874BFD', '#7D56F4']
 special            = ['#43BF6D', '#73F59F']
 filtered           = ['#A9A9A9', '#555555']
@@ -65,7 +65,7 @@ max_rating = 0 # Exclude songs with a rating less than or equal to this number (
   top            = ['gg']
   bottom         = ['G']
   select         = ['enter']
-  play_shuffeled = ['alt+enter']
+  play_shuffled = ['alt+enter']
 
   [keybinds.search]
   focus_search = ['/']

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -111,7 +111,7 @@ func (m model) handlesKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if keyMatches(key, api.AppConfig.Keybinds.Navigation.PlayShuffled) {
-		return playShuffeled(m)
+		return playShuffled(m)
 	}
 
 	// SEARCH KEYBINDS
@@ -386,7 +386,7 @@ func enter(m model) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func playShuffeled(m model) (tea.Model, tea.Cmd) {
+func playShuffled(m model) (tea.Model, tea.Cmd) {
 	switch m.focus {
 	case focusMain:
 		if m.displayMode == displayAlbums && m.cursorMain < len(m.albums) && (m.albums[m.cursorMain]).ID != "" {


### PR DESCRIPTION
Changes all references of shuffeled to shuffled. There is one other usage of shuffeled in [the wiki](https://github.com/MattiaPun/SubTUI/wiki/Keybinds-and-Filters) which I could not edit. The line with the typo is `keybinds.navigation.play_shuffeled`