### PR TITLE
fix: prevent index out of bounds panic in media player when queue is empty

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1254,11 +1254,26 @@ func truncate(s string, width int) string {
 		return ""
 	}
 
-	if len(s) > width {
-		return s[:width-1] + "…"
+	stringWidth := runewidth.StringWidth(s)
+	if stringWidth <= width {
+		return s
 	}
 
-	return s
+	currentWidth := 0
+	result := ""
+
+	for _, r := range s {
+		w := runewidth.RuneWidth(r)
+
+		if currentWidth+w+1 > width { // +1 for ellipsis
+			break
+		}
+
+		result += string(r)
+		currentWidth += w
+	}
+
+	return result + "…"
 }
 
 // Helper: Cut of string OR add padding to get specified width


### PR DESCRIPTION
## Bug
Fixes #87 and #85 — two related issues in the media player:
1. App was panicking when in the media player view with an empty queue (issue #87)
2. UTF-8 characters were being truncated improperly in the Side Queue View (issue #85)

## Fix
**Index out of bounds fix (#87):**
Changed the bounds check in `mediaPlayerSideSongContent` from `m.queueIndex > len(m.queue)` to `len(m.queue) == 0 || m.queueIndex >= len(m.queue)` to properly handle:
- Empty queue scenarios  
- Queue index equal to queue length (out of bounds access)

**UTF-8 truncation fix (#85):**
Updated the `truncate` function to use `runewidth` for proper UTF-8 character handling, similar to how `LimitString` works. This prevents cutting UTF-8 characters in the middle and causing display corruption.

## Testing
- The index bounds fix prevents the "index out of range [0] with length 0" panic when playing a single song that reaches the end while viewing the media player
- The UTF-8 fix ensures proper truncation of non-ASCII characters in song titles and artist names in the queue view

Greetings, saschabuehrle