### PR TITLE
feat(controls): add 0-5 keys for ratings

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -150,6 +150,12 @@ type LibraryKeybinds struct {
 	AddRating     []string `toml:"add_rating"`
 	GoToAlbum     []string `toml:"go_to_album"`
 	GoToArtist    []string `toml:"go_to_artist"`
+	Rate0         []string `toml:"rate_0"`
+	Rate1         []string `toml:"rate_1"`
+	Rate2         []string `toml:"rate_2"`
+	Rate3         []string `toml:"rate_3"`
+	Rate4         []string `toml:"rate_4"`
+	Rate5         []string `toml:"rate_5"`
 }
 
 type MediaKeybinds struct {

--- a/internal/api/config.toml
+++ b/internal/api/config.toml
@@ -77,6 +77,12 @@ max_rating = 0 # Exclude songs with a rating less than or equal to this number (
   add_rating      = ['R']
   go_to_album     = ['ga']
   go_to_artist    = ['gr']
+  rate_0          = ['0']
+  rate_1          = ['1']
+  rate_2          = ['2']
+  rate_3          = ['3']
+  rate_4          = ['4']
+  rate_5          = ['5']
 
   [keybinds.media]
   play_pause          = ['p', 'P']

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -128,6 +128,30 @@ func (m model) handlesKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return toggleAddRatingPopup(m), nil
 	}
 
+	if keyMatches(key, api.AppConfig.Keybinds.Library.Rate0) {
+		return setRating(m, 0)
+	}
+
+	if keyMatches(key, api.AppConfig.Keybinds.Library.Rate1) {
+		return setRating(m, 1)
+	}
+
+	if keyMatches(key, api.AppConfig.Keybinds.Library.Rate2) {
+		return setRating(m, 2)
+	}
+
+	if keyMatches(key, api.AppConfig.Keybinds.Library.Rate3) {
+		return setRating(m, 3)
+	}
+
+	if keyMatches(key, api.AppConfig.Keybinds.Library.Rate4) {
+		return setRating(m, 4)
+	}
+
+	if keyMatches(key, api.AppConfig.Keybinds.Library.Rate5) {
+		return setRating(m, 5)
+	}
+
 	// MEDIA KEYBINDS
 	if keyMatches(key, api.AppConfig.Keybinds.Media.PlayPause) {
 		return mediaTogglePlay(m, msg), nil
@@ -1410,6 +1434,33 @@ func ratingMenu(key string, m model) (model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func setRating(m model, rating int) (tea.Model, tea.Cmd) {
+	if !cursorInBounds(m) {
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	switch m.displayMode {
+	case displaySongs:
+		switch m.viewMode {
+		case viewList:
+			m.songs[m.cursorMain].Rating = rating
+			cmd = addRatingCmd(m.songs[m.cursorMain].ID, rating)
+		case viewQueue:
+			m.queue[m.cursorMain].Rating = rating
+			cmd = addRatingCmd(m.queue[m.cursorMain].ID, rating)
+		}
+	case displayAlbums:
+		m.albums[m.cursorMain].Rating = rating
+		cmd = addRatingCmd(m.albums[m.cursorMain].ID, rating)
+	case displayArtist:
+		m.artists[m.cursorMain].Rating = rating
+		cmd = addRatingCmd(m.artists[m.cursorMain].ID, rating)
+	}
+
+	return m, cmd
 }
 
 // Helper for infinte scrolling

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1122,6 +1122,12 @@ func helpViewContent() string {
 		line(keys(api.AppConfig.Keybinds.Library.AddRating), "Add rating"),
 		line(keys(api.AppConfig.Keybinds.Library.GoToAlbum), "Go to album"),
 		line(keys(api.AppConfig.Keybinds.Library.GoToArtist), "Go to artist"),
+		line(keys(api.AppConfig.Keybinds.Library.Rate0), "Rate 0"),
+		line(keys(api.AppConfig.Keybinds.Library.Rate1), "Rate 1"),
+		line(keys(api.AppConfig.Keybinds.Library.Rate2), "Rate 2"),
+		line(keys(api.AppConfig.Keybinds.Library.Rate3), "Rate 3"),
+		line(keys(api.AppConfig.Keybinds.Library.Rate4), "Rate 4"),
+		line(keys(api.AppConfig.Keybinds.Library.Rate5), "Rate 5"),
 	)
 
 	mediaKeybinds := section("MEDIA",


### PR DESCRIPTION
This PR implements key binds for rating songs/albums/artists with the 0-5 keys. Configurable key binds can be set in `config.toml`.

Resolves #81 