### PR TITLE
feat(controls): added half page scroll up and down

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -137,8 +137,8 @@ type NavigationKeybinds struct {
 	Bottom       []string `toml:"bottom"`
 	Select       []string `toml:"select"`
 	PlayShuffled []string `toml:"play_shuffled"`
-	ScrollUp     []string `toml:"scroll_up"`
-	ScrollDown   []string `toml:"scroll_down"`
+	GoHalfPageUp     []string `toml:"go_half_page_up"`
+	GoHalfPageDown   []string `toml:"go_half_page_down"`
 }
 
 type SearchKeybinds struct {

--- a/internal/api/config.toml
+++ b/internal/api/config.toml
@@ -66,8 +66,8 @@ max_rating = 0 # Exclude songs with a rating less than or equal to this number (
   bottom         = ['G']
   select         = ['enter']
   play_shuffled  = ['alt+enter']
-  scroll_up      = ['ctrl+u']
-  scroll_down    = ['ctrl+d']
+  go_half_page_up = ['ctrl+u']
+  go_half_page_down = ['ctrl+d']
 
   [keybinds.search]
   focus_search = ['/']

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -114,11 +114,11 @@ func (m model) handlesKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return playShuffled(m)
 	}
 
-	if keyMatches(key, api.AppConfig.Keybinds.Navigation.ScrollUp) {
+	if keyMatches(key, api.AppConfig.Keybinds.Navigation.GoHalfPageUp) {
 		return navigateUp(m, (m.height-17)/2), nil
 	}
 
-	if keyMatches(key, api.AppConfig.Keybinds.Navigation.ScrollDown) {
+	if keyMatches(key, api.AppConfig.Keybinds.Navigation.GoHalfPageDown) {
 		return navigateDown(m, (m.height-17)/2)
 	}
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1109,6 +1109,8 @@ func helpViewContent() string {
 		line(keys(api.AppConfig.Keybinds.Navigation.Bottom), "Go to bottom"),
 		line(keys(api.AppConfig.Keybinds.Navigation.Select), "Select"),
 		line(keys(api.AppConfig.Keybinds.Navigation.PlayShuffled), "Start shuffled"),
+		line(keys(api.AppConfig.Keybinds.Navigation.GoHalfPageUp), "Go half page up"),
+		line(keys(api.AppConfig.Keybinds.Navigation.GoHalfPageDown), "Go half page down"),
 	)
 
 	searchKeybinds := section("SEARCH",


### PR DESCRIPTION
Added half page scroll up and down navigation, mimicking Vim's `Ctrl+U` and `Ctrl+D` behaviour.

These keybinds can be changed in the config under `keybinds.navigation.scroll_up` and `keybinds.navigation.scroll_down` respectively.

I just reused the logic that was already there for standard navigation but added a new `steps` arg.

Let me know if there is anything wrong!