### PR TITLE
Update flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,10 @@
             buildInputs = [ pkgs.mpv ];
 
             ldflags = [ "-s" "-w" ];
+            
+            postInstall = ''
+              mv $out/bin/SubTUI $out/bin/subtui
+            '';
 
             meta = with lib; {
               description = "A lightweight Subsonic TUI music player with scrobbling and mpv backend";


### PR DESCRIPTION
Currently `nix run github:MattiaPun/SubTUI` fails with 

```sh
/nix/store/vka5h05hsjrwc50k8hm909zwlar9i1fp-subtui-unstable-dev/bin/SubTUI](error: unable to execute '/nix/store/vka5h05hsjrwc50k8hm909zwlar9i1fp-subtui-unstable-dev/bin/SubTUI': No such file or directory)
```

The binary has the incorrect casing. This postInstall line makes `nix run` work. I believe there is an alternative to rename the go binary?