### PR TITLE
fix(ui): cover art section is hidden on media player when disabled

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -747,7 +747,6 @@ func mediaPlayerContent(m model) string {
 func mediaPlayerSideContent(m model, width int, height int) string {
 	var mediaPlayerSongContent string
 	var mediaPlayerQueueContent string
-	var mediaPlayerCoverArtContent string
 
 	var mediaInfoHeight int
 	var queueHeight int
@@ -763,27 +762,29 @@ func mediaPlayerSideContent(m model, width int, height int) string {
 		Render(mediaPlayerSideSongContent(m, width, mediaInfoHeight))
 
 	// Queue
+	if m.coverArt == nil {
+		queueHeight = height - lipgloss.Height(mediaPlayerSongContent) + 1
+	}
 	mediaPlayerQueueContent = borderStyle.
 		Width(width).
 		Height(queueHeight).
-		Render(mediaPlayerSideQueueContent(m, width))
+		Render(mediaPlayerSideQueueContent(m, width, queueHeight))
+
+	sections := []string{mediaPlayerSongContent, mediaPlayerQueueContent}
 
 	// Cover Art
-	coverArtHeight = height - lipgloss.Height(mediaPlayerSongContent) - lipgloss.Height(mediaPlayerQueueContent) + 1
-	mediaPlayerCoverArtContent = borderStyle.
-		Width(width).
-		Height(coverArtHeight).
-		Align(lipgloss.Center).
-		AlignVertical(lipgloss.Center).
-		Render(mediaPlayerSideCoverArtContent(m))
+	if m.coverArt != nil { // only render if enabled
+		coverArtHeight = height - lipgloss.Height(mediaPlayerSongContent) - lipgloss.Height(mediaPlayerQueueContent) + 1
+		sections = append(sections, borderStyle.
+			Width(width).
+			Height(coverArtHeight).
+			Align(lipgloss.Center).
+			AlignVertical(lipgloss.Center).
+			Render(m.coverMosaic.Render(m.coverArt)))
+	}
 
 	// Combining
-	return lipgloss.JoinVertical(
-		lipgloss.Left,
-		mediaPlayerSongContent,
-		mediaPlayerQueueContent,
-		mediaPlayerCoverArtContent,
-	)
+	return lipgloss.JoinVertical(lipgloss.Left, sections...)
 }
 
 // Generate the media player song information
@@ -905,15 +906,17 @@ func mediaPlayerSideSongContent(m model, width int, height int) string {
 }
 
 // Generate the media player queue
-func mediaPlayerSideQueueContent(m model, width int) string {
+func mediaPlayerSideQueueContent(m model, width int, height int) string {
 	var header string
 	var separator string
 	var queue string
+	var songCount int
 
 	header = highlightStyle.Bold(true).Render(" Next up:")
 	separator = strings.Repeat("-", width)
+	songCount = height - 2 // 2: header + seperator
 
-	for i := 1; i <= 5; i++ {
+	for i := 1; i <= songCount; i++ {
 		if m.queueIndex+i < len(m.queue) {
 			song := m.queue[m.queueIndex+i]
 			queue += truncate(fmt.Sprintf(" %d. %s - %s", i, song.Title, song.Artist), width) + "\n"
@@ -931,17 +934,6 @@ func mediaPlayerSideQueueContent(m model, width int) string {
 		separator,
 		queue,
 	)
-}
-
-// Generate the media player art cover
-func mediaPlayerSideCoverArtContent(m model) string {
-	if m.coverArt == nil {
-		// No album art
-		return "No album art to display"
-	} else {
-		// Display album art
-		return m.coverMosaic.Render(m.coverArt)
-	}
 }
 
 // Generate the media player lyrics

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -919,7 +919,8 @@ func mediaPlayerSideQueueContent(m model, width int, height int) string {
 	for i := 1; i <= songCount; i++ {
 		if m.queueIndex+i < len(m.queue) {
 			song := m.queue[m.queueIndex+i]
-			queue += truncate(fmt.Sprintf(" %d. %s - %s", i, song.Title, song.Artist), width) + "\n"
+			songIndexString := LimitString(fmt.Sprintf(" %d.", m.queueIndex+i+1), 4)
+			queue += truncate(fmt.Sprintf("%s %s - %s", songIndexString, song.Title, song.Artist), width) + "\n"
 		} else {
 			queue += "\n"
 		}


### PR DESCRIPTION
Fixes: #108

Made it so the queue section extends till the bottom. Songs are filled dynamically depending on the height.

This is with the cover art enabled:
<img width="2531" height="1353" alt="image" src="https://github.com/user-attachments/assets/4a91e23b-503d-43d0-bcc0-3b56894645eb" />


and disabled:
<img width="2532" height="1361" alt="image" src="https://github.com/user-attachments/assets/af7fb8ab-b53c-4c0d-a9d0-7a08ac885897" />


Let me know what you think :)

I will also use this pr to ask you something about this queue view.
Does the numbering make sense here? I ask you this because it's static. Take for example this queue:
```
aaaa
bbbb
cccc
dddd
eeee
ffff
gggg
```
The current song playing is `aaaa`
In the media player (when an album art is shown) it will show like this:
```
Next up
---
1. bbbb
2. cccc
3. dddd
4. eeee
5. ffff
```

Now song `aaaa` ended and `bbbb` is playing, it will show like this:
```
Next up
---
1. cccc
2. dddd
3. eeee
4. ffff
5. gggg
```

so now `cccc` is number 1, but wouldn't it make sense to be like this:
```
Next up
---
3. cccc
4. dddd
5. eeee
6. ffff
7. gggg
```

keeping the default queue numbering order? Or just remove the numbering? What do you think?