### PR TITLE
fix(ui): coverArt filetype generalized, added support for png,webp

### DIFF
--- a/internal/ui/cmds_api.go
+++ b/internal/ui/cmds_api.go
@@ -2,11 +2,14 @@ package ui
 
 import (
 	"bytes"
-	"image/jpeg"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
 	"path/filepath"
 
 	"github.com/MattiaPun/SubTUI/v2/internal/api"
 	tea "github.com/charmbracelet/bubbletea"
+	_ "golang.org/x/image/webp"
 )
 
 func attemptLoginCmd() tea.Cmd {
@@ -149,7 +152,7 @@ func getCoverArtCmd(songID string) tea.Cmd {
 			return nil
 		}
 
-		img, err := jpeg.Decode(bytes.NewReader(imgData))
+		img, _, err := image.Decode(bytes.NewReader(imgData))
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
## Changes
- `jpeg.Decode` -> `image.Decode`
- added dependencies: `image`, `image/png`, `golang.org/x/image/webp`

## Explanation
Fixes a bug I was having similar to #111 where navidrome was sending webp coverArt which couldn't be decoded with `image/jpeg`. Now using the more general `image.Decode` and loading webp, png, jpeg dependencies to support these filetypes.