### PR TITLE
feat: default volume configuration

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -54,6 +54,7 @@ type App struct {
 	Notifications   bool   `toml:"desktop_notifications"`
 	DiscordRPC      bool   `toml:"discord_rich_presence"`
 	MouseSupport    bool   `toml:"mouse_support"`
+	Volume          int    `toml:"default_volume"`
 }
 
 type Theme struct {

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -54,7 +54,7 @@ type App struct {
 	Notifications   bool   `toml:"desktop_notifications"`
 	DiscordRPC      bool   `toml:"discord_rich_presence"`
 	MouseSupport    bool   `toml:"mouse_support"`
-	Volume          int    `toml:"default_volume"`
+	Volume          int    `toml:"default_volume" comment:"0-100 for a preset initial volume, -1 to disable"`
 }
 
 type Theme struct {

--- a/internal/api/config.toml
+++ b/internal/api/config.toml
@@ -4,6 +4,7 @@ gapless_playback = 'yes' # Options:  'yes', 'no', 'weak' https://mpv.io/manual/s
 desktop_notifications = true
 discord_rich_presence = true
 mouse_support         = false
+default_volume = -1  # Use -1 to let the player set volume, or 0-100 for a preset initial volume
 
 [theme]
 display_album_art  = true

--- a/internal/api/config.toml
+++ b/internal/api/config.toml
@@ -4,7 +4,7 @@ gapless_playback = 'yes' # Options:  'yes', 'no', 'weak' https://mpv.io/manual/s
 desktop_notifications = true
 discord_rich_presence = true
 mouse_support         = false
-default_volume = -1  # Use -1 to let the player set volume, or 0-100 for a preset initial volume
+default_volume = -1  # 0-100 for a preset initial volume, -1 to disable
 
 [theme]
 display_album_art  = true

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -156,19 +156,13 @@ func Forward10Seconds() {
 }
 
 func VolumeUp() {
-	if mpvClient.CurrentVolume()+volumeStep > 100 {
-		_ = mpvClient.Volume(100)
-		return
-	}
-	_ = mpvClient.Volume(mpvClient.CurrentVolume() + volumeStep)
+	newVolume := ((mpvClient.CurrentVolume() / volumeStep) + 1) * volumeStep
+	SetVolume(newVolume)
 }
 
 func VolumeDown() {
-	if mpvClient.CurrentVolume()-volumeStep < 0 {
-		_ = mpvClient.Volume(0)
-		return
-	}
-	_ = mpvClient.Volume(mpvClient.CurrentVolume() - volumeStep)
+	newVolume := ((mpvClient.CurrentVolume() - 1) / volumeStep) * volumeStep
+	SetVolume(newVolume)
 }
 
 func GetVolume() float64 {
@@ -177,6 +171,11 @@ func GetVolume() float64 {
 }
 
 func SetVolume(volume int) {
+	if volume < 0 {
+		volume = 0
+	} else if volume > 100 {
+		volume = 100
+	}
 	_ = mpvClient.Volume(volume)
 }
 

--- a/internal/ui/update_messages.go
+++ b/internal/ui/update_messages.go
@@ -225,6 +225,11 @@ func (m model) handleLoginResult(msg loginResultMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Initialize volume
+	if api.AppConfig.App.Volume != -1 {
+		player.SetVolume(api.AppConfig.App.Volume)
+	}
+
 	m.viewMode = viewList
 	m.focus = focusSearch
 	m.loginErr = ""


### PR DESCRIPTION
Added `default_volume` option to App section of config. Addresses #109

### Configuration Details

- `default_volume = -1` (default): The player controls initial volume (current behavior). In my case mpv is persisting my previous session volume somehow, which I prefer over a set default.
- `default_volume = 0-100`: Sets a specific default volume on startup.
- `default_volume > 100` or `< 0` (except -1): Values are automatically clamped to the 0-100 range.

### Volume Adjustment Behavior

1. Adjustments now snap to the nearest multiple of `volumeStep` if not already aligned (e.g., 43 goes up to 45, down to 40)
2. If already a multiple, behaves as before

---

## Additional Notes

I noticed some redundancy between for example `mpvClient.CurrentVolume` and `player.GetVolume`, which could be considered in a future refactor / code cleanup.
