### PR TITLE
fix(scrobble): send now playing status for next song in queue

### DIFF
--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -97,8 +97,6 @@ func PlaySong(songID string, startPaused bool) error {
 		return err
 	}
 
-	api.SubsonicScrobble(songID, false)
-
 	_ = mpvClient.SetProperty("pause", startPaused)
 
 	return nil

--- a/internal/ui/update_messages.go
+++ b/internal/ui/update_messages.go
@@ -312,6 +312,9 @@ func (m model) handleStatus(msg statusMsg) (tea.Model, tea.Cmd) {
 		m.lastPlayedSongPath = m.playerStatus.Path // Update previous song
 		m.scrobbled = false                        // Reset scrobble status
 
+		// Update current scroble (just the playing now, not a submission)
+		go api.SubsonicScrobble(currentSong.ID, false)
+
 		// Setup metadata
 		metadata := integration.Metadata{
 			Title:    currentSong.Title,


### PR DESCRIPTION
When the queue advances to the next song, the "now playing" status was never sent to the server since that call only existed in the `PlaySong` function. So it would only appear on the first song played from a queue, album, ... or when using the next or back song button.

So I moved the now playing scrobble to the song change detection block in `handleStatus`, so it fires on every song transition regardless of how the song changed. Also removed it from the `PlaySong` so it does not fire twice.

Let me know what you think :)

