### PR TITLE
Added Void Linux Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Pre-compiled binaries for Linux and macOS are available on the [Releases](https:
 | **macOS (Homebrew)** 	| `brew install MattiaPun/subtui/subtui`                                         	|
 | **FreeBSD**          	| `pkg install subtui`                                                           	|
 | **Nix**              	| `nix profile install github:MattiaPun/SubTUI`                                  	|
+| **Void Linux**        | `xbps-install SubTUI`                                                             |
 | **Go Toolchain**     	| `go install github.com/MattiaPun/SubTUI@latest`                                	|
 | **From Source**      	| `git clone https://github.com/MattiaPun/SubTUI.git && cd SubTUI && go build .` 	|
 


### PR DESCRIPTION
I'm now the maintainer for the SubTUI package in Void's official repo. 
https://github.com/void-linux/void-packages/tree/master/srcpkgs/SubTUI