### PR TITLE
Fix: missing case for `esc` out of the help menu

### DIFF
--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -1599,14 +1599,15 @@ func login(m model, msg tea.KeyMsg) (model, tea.Cmd) {
 func playerMenu(m model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
+	// Toggle help overlay
 	if keyMatches(key, api.AppConfig.Keybinds.Global.Help) {
 		m.showHelp = !m.showHelp
 		return m, nil
-	} else if m.showHelp {
-		if keyMatches(key, api.AppConfig.Keybinds.Global.Back) {
-			m.showHelp = false
-			return m, nil
-		}
+	}
+
+	// Close help overlay
+	if keyMatches(key, api.AppConfig.Keybinds.Global.Back) && m.showHelp {
+		m.showHelp = false
 		return m, nil
 	}
 

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -1603,6 +1603,10 @@ func playerMenu(m model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.showHelp = !m.showHelp
 		return m, nil
 	} else if m.showHelp {
+		if keyMatches(key, api.AppConfig.Keybinds.Global.Back) {
+			m.showHelp = false
+			return m, nil
+		}
 		return m, nil
 	}
 


### PR DESCRIPTION
I noticed that I couldn't go "back" with the `esc` key while having the help menu up and being on the Media Player page, aka closing the help menu.

The change simply adds this case. 
Not familiar with the entire codebase, so lmk if I have missed something. 


Where it happens:
<img width="979" height="1004" alt="Screenshot 2026-05-20 at 13 54 19" src="https://github.com/user-attachments/assets/302940d8-0812-4fe0-85b3-e1a15ba75a64" />
