### PR TITLE
feat(controls): added pageup/pagedown

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -140,6 +140,8 @@ type NavigationKeybinds struct {
 	Select          []string `toml:"select"`
 	ToggleSelection []string `toml:"toggle_selection"`
 	PlayShuffled    []string `toml:"play_shuffled"`
+	GoPageUp        []string `toml:"go_page_up"`
+	GoPageDown      []string `toml:"go_page_down"`
 	GoHalfPageUp    []string `toml:"go_half_page_up"`
 	GoHalfPageDown  []string `toml:"go_half_page_down"`
 }

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -49,12 +49,16 @@ type Security struct {
 }
 
 type App struct {
-	ReplayGain      string `toml:"replaygain" comment:"Type of replaygain: 'track', 'album', 'no' https://mpv.io/manual/stable/#options-replaygain"`
-	GaplessPlayBack string `toml:"gapless_playback" comment:"Type of gapless playback: 'yes', 'no', 'weak' https://mpv.io/manual/stable/#options-gapless-audio"`
-	Notifications   bool   `toml:"desktop_notifications"`
-	DiscordRPC      bool   `toml:"discord_rich_presence"`
-	MouseSupport    bool   `toml:"mouse_support"`
-	Volume          int    `toml:"default_volume" comment:"0-100 for a preset initial volume, -1 to disable"`
+	ReplayGain        	string 	`toml:"replaygain" comment:"Type of replaygain: 'track', 'album', 'no' https://mpv.io/manual/stable/#options-replaygain"`
+	GaplessPlayBack  	string 	`toml:"gapless_playback" comment:"Type of gapless playback: 'yes', 'no', 'weak' https://mpv.io/manual/stable/#options-gapless-audio"`
+	Notifications     	bool   	`toml:"desktop_notifications"`
+	DiscordRPC        	bool   	`toml:"discord_rich_presence"`
+	MouseSupport  		bool   	`toml:"mouse_support"`
+	Volume            	int    	`toml:"default_volume" comment:"0-100 for a preset initial volume, -1 to disable"`
+	StartUpActive	  	int 	`toml:"startup_active" comment:"Which panel should be active on startup(int): 0:search, 1:side, 2:main', 3:player"`
+	StartUpPlayerView 	bool 	`toml:"startup_player_view"`
+	PlayOnStartUp		bool 	`toml:"play_on_startup"`
+	StartUpLoopMode		int		`toml:"startup_loop_mode" comment:"int: 0:no 1:all 2:one"`
 }
 
 type Theme struct {

--- a/internal/api/config.toml
+++ b/internal/api/config.toml
@@ -69,6 +69,8 @@ max_rating = 0 # Exclude songs with a rating less than or equal to this number (
   select            = ['enter']
   toggle_selection  = ['x']
   play_shuffled     = ['alt+enter']
+  go_page_up        = ['pgup']
+  go_page_down      = ['pgdown']
   go_half_page_up   = ['ctrl+u']
   go_half_page_down = ['ctrl+d']
 

--- a/internal/api/config.toml
+++ b/internal/api/config.toml
@@ -5,6 +5,10 @@ desktop_notifications = true
 discord_rich_presence = true
 mouse_support         = false
 default_volume = -1  # 0-100 for a preset initial volume, -1 to disable
+startup_active = 0 # Options(int): 0:search, 1:side, 2:main, 3:player
+startup_player_view = false
+play_on_startup = false
+startup_loop_mode = 0 # Options(int): 0:no, 1:all, 2:one
 
 [theme]
 display_album_art  = true

--- a/internal/ui/init.go
+++ b/internal/ui/init.go
@@ -24,7 +24,7 @@ func InitialModel() model {
 	return model{
 		textInput:          ti,
 		songs:              []api.Song{},
-		focus:              focusSearch,
+		focus:              api.AppConfig.App.StartUpActive,
 		cursorMain:         0,
 		cursorSide:         0,
 		cursorPopup:        0,
@@ -38,12 +38,13 @@ func InitialModel() model {
 		lastPlayedSongPath: "",
 		loginInputs:        initialLoginInputs(),
 		lastKey:            "",
-		showMediaPlayer:    false,
+		showMediaPlayer:    api.AppConfig.App.StartUpPlayerView,
 		showHelp:           false,
 		showPlaylists:      false,
 		helpModel:          NewHelpModel(),
 		discordRPC:         api.AppConfig.App.DiscordRPC,
 		notify:             api.AppConfig.App.Notifications,
+		loopMode:           api.AppConfig.App.StartUpLoopMode,
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -63,9 +63,10 @@ type model struct {
 	discordInstance *integration.DiscordInstance
 
 	// Queue System
-	queue      []api.Song
-	queueIndex int
-	loopMode   int
+	queue         []api.Song
+	queueIndex    int
+	loopMode      int
+	playAfterLoad bool
 
 	// Stars
 	starredMap map[string]bool

--- a/internal/ui/queue.go
+++ b/internal/ui/queue.go
@@ -15,13 +15,21 @@ func formatDuration(seconds int) string {
 	return fmt.Sprintf("%d:%02d", minutes, secs)
 }
 
-func (m *model) playQueueIndex(index int, startPaused bool) tea.Cmd {
+func (m *model) playQueueIndex(index int, fromServer bool) tea.Cmd {
 	if index < 0 || index >= len(m.queue) {
 		return nil
 	}
 
 	m.queueIndex = index
 	song := m.queue[m.queueIndex]
+	startPaused := fromServer
+	if m.playAfterLoad {
+		startPaused = false
+		if m.viewMode == viewQueue {
+			m.cursorMain, m.mainOffset = seekToQueueIndex(*m)
+		}
+		m.playAfterLoad = false
+	}
 
 	playCmd := func() tea.Msg {
 		err := player.PlaySong(song.ID, startPaused)
@@ -45,9 +53,12 @@ func (m *model) playQueueIndex(index int, startPaused bool) tea.Cmd {
 		return nil
 	}
 
+	var saveCmd tea.Cmd
+	if !fromServer {
+		saveCmd = m.savePlayQueue()
+	}
 	return tea.Batch(
-		playCmd,
-		m.savePlayQueue(),
+		playCmd, saveCmd,
 	)
 }
 

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -302,19 +302,21 @@ func focusSearchBar(m model) model {
 }
 
 func cycleFocus(m model, forward bool) model {
-	// Cycles Focus: Search -> Sidebar -> Main -> Song -> Search
-	if forward {
-		m.focus = (m.focus + 1) % 4
-	} else {
-		m.focus = (((m.focus-1)%4 + 4) % 4)
-	}
-
+	// Cycles Focus: Search -> Sidebar -> Main -> Song -> Sidebar
 	if m.focus == focusSearch {
-		m.textInput.Focus()
-	} else {
 		m.textInput.Blur()
+		if forward {
+			m.focus = focusSidebar
+		} else {
+			m.focus = focusSong
+		}
+	} else {
+		v := 2
+		if forward {
+			v = 1
+		}
+		m.focus = (m.focus - 1 + v) % 3 + 1
 	}
-
 	return m
 }
 
@@ -887,6 +889,11 @@ func cycleFilter(m model, forward bool) model {
 	return m
 }
 
+func seekToQueueIndex(m model) (int, int) {
+	return m.queueIndex, max(0, min(m.queueIndex - 2,
+		_getMainListLength(m) - _getMainVisibleRows(m)))
+}
+
 func toggleQueue(m model) model {
 	if m.focus != focusSearch {
 		switch m.viewMode {
@@ -894,9 +901,7 @@ func toggleQueue(m model) model {
 			m.viewMode = viewQueue
 			m.displayModePrev = m.displayMode
 			m.displayMode = displaySongs
-			m.cursorMain = m.queueIndex
-			m.mainOffset = max(0, min(m.queueIndex - 2,
-				_getMainListLength(m) - _getMainVisibleRows(m)))
+			m.cursorMain, m.mainOffset = seekToQueueIndex(m)
 		case viewQueue:
 			m.viewMode = viewList
 			m.displayMode = m.displayModePrev

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -895,11 +895,8 @@ func toggleQueue(m model) model {
 			m.displayModePrev = m.displayMode
 			m.displayMode = displaySongs
 			m.cursorMain = m.queueIndex
-			if m.cursorMain > 2 {
-				m.mainOffset = m.cursorMain - 2
-			} else {
-				m.mainOffset = 0
-			}
+			m.mainOffset = max(0, min(m.queueIndex - 2,
+				_getMainListLength(m) - _getMainVisibleRows(m)))
 		case viewQueue:
 			m.viewMode = viewList
 			m.displayMode = m.displayModePrev

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -118,6 +118,14 @@ func (m model) handlesKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return playShuffled(m)
 	}
 
+	if keyMatches(key, api.AppConfig.Keybinds.Navigation.GoPageUp) {
+		return navigatePageUp(m), nil
+	}
+
+	if keyMatches(key, api.AppConfig.Keybinds.Navigation.GoPageDown) {
+		return navigatePageDown(m)
+	}
+
 	if keyMatches(key, api.AppConfig.Keybinds.Navigation.GoHalfPageUp) {
 		return navigateUp(m, (m.height-17)/2), nil
 	}
@@ -543,6 +551,49 @@ func goBack(m model) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func _getMainListLength(m model) int {
+	switch m.displayMode {
+	case displaySongs:
+		if m.viewMode == viewQueue {
+			return len(m.queue)
+		} else {
+			return len(m.songs)
+		}
+	case displayAlbums:
+		return len(m.albums)
+	case displayArtist:
+		return len(m.artists)
+	}
+	return 0
+}
+
+func _getMainVisibleRows(m model) int {
+	// Height - Search(3) - Footer(6) - Margins(4) - TableHeader(2) = 17
+	return max(1, m.height - 17)
+}
+
+func _getSideLenAndRows(m model) (int, int) {
+	sideLen := len(albumTypes) + len(m.playlists)
+
+	headerHeight := 1
+
+	footerHeight := int(float64(m.height) * 0.10)
+	if footerHeight < 5 {
+		footerHeight = 5
+	}
+
+	mainHeight := m.height - headerHeight - footerHeight - (3 * 2) // 3 sections with each 2 borders (top and bottom)
+	if mainHeight < 0 {
+		mainHeight = 0
+	}
+
+	visibleRows := mainHeight - 6 // Conservative estimate for headers
+	if visibleRows < 1 {
+		visibleRows = 1
+	}
+	return sideLen, visibleRows
+}
+
 func navigateTop(m model) model {
 	switch m.focus {
 	case focusMain:
@@ -564,22 +615,7 @@ func navigateTop(m model) model {
 func navigateBottom(m model) (model, tea.Cmd) {
 	switch m.focus {
 	case focusMain:
-
-		listLen := 0
-
-		switch m.displayMode {
-		case displaySongs:
-			if m.viewMode == viewQueue {
-				listLen = len(m.queue)
-			} else {
-				listLen = len(m.songs)
-			}
-		case displayAlbums:
-			listLen = len(m.albums)
-		case displayArtist:
-			listLen = len(m.artists)
-		}
-
+		listLen := _getMainListLength(m)
 		m.cursorMain = listLen - 1
 		if m.height-17 >= 17 && listLen >= 17 {
 			m.mainOffset = listLen - 17
@@ -592,28 +628,11 @@ func navigateBottom(m model) (model, tea.Cmd) {
 		}
 
 	case focusSidebar:
-		total := len(albumTypes) + len(m.playlists)
-		m.cursorSide = total - 1
+		sideLen, visibleRows := _getSideLenAndRows(m)
+		m.cursorSide = sideLen - 1
 
-		headerHeight := 1
-
-		footerHeight := int(float64(m.height) * 0.10)
-		if footerHeight < 5 {
-			footerHeight = 5
-		}
-
-		mainHeight := m.height - headerHeight - footerHeight - (3 * 2) // 3 sections with each 2 borders (top and bottom)
-		if mainHeight < 0 {
-			mainHeight = 0
-		}
-
-		visibleRows := mainHeight - 6 // Conservative estimate for headers
-		if visibleRows < 1 {
-			visibleRows = 1
-		}
-
-		if total > visibleRows {
-			m.sideOffset = total - visibleRows
+		if sideLen > visibleRows {
+			m.sideOffset = sideLen - visibleRows
 		} else {
 			m.sideOffset = 0
 		}
@@ -645,39 +664,22 @@ func navigateUp(m model, steps int) model {
 		if m.cursorSide < m.sideOffset {
 			m.sideOffset = m.cursorSide
 		}
-		if m.cursorSide < m.sideOffset {
-			m.sideOffset = m.cursorSide
-		}
 	}
 
 	return m
 }
 
 func navigateDown(m model, steps int) (model, tea.Cmd) {
-	listLen := 0
-	if m.viewMode == viewQueue {
-		listLen = len(m.queue)
-	} else if m.displayMode == displaySongs {
-		listLen = len(m.songs)
-	} else if m.displayMode == displayAlbums {
-		listLen = len(m.albums)
-	} else if m.displayMode == displayArtist {
-		listLen = len(m.artists)
-	}
-
-	albumOffset := len(albumTypes)
-
 	switch m.focus {
 	case focusMain:
+		listLen := _getMainListLength(m)
 		if m.cursorMain < listLen-1 {
 			m.cursorMain += steps
-
 			if m.cursorMain > listLen-1 {
 				m.cursorMain = listLen - 1
 			}
 
-			// Height - Search(3) - Footer(6) - Margins(4) - TableHeader(2) = 17
-			visibleRows := m.height - 17
+			visibleRows := _getMainVisibleRows(m)
 			if m.cursorMain >= m.mainOffset+visibleRows {
 				m.mainOffset = m.cursorMain - visibleRows + 1
 			}
@@ -688,30 +690,12 @@ func navigateDown(m model, steps int) (model, tea.Cmd) {
 		}
 
 	case focusSidebar:
-		if m.cursorSide < len(m.playlists)+albumOffset-1 { // + because of the Album offset
+		sideLen, visibleRows := _getSideLenAndRows(m)
+		if m.cursorSide < sideLen-1 {
 			m.cursorSide += steps
-
-			if m.cursorSide > len(m.playlists)+albumOffset-1 {
-				m.cursorSide = len(m.playlists) + albumOffset - 1
+			if m.cursorSide > sideLen-1 {
+				m.cursorSide = sideLen - 1
 			}
-
-			headerHeight := 1
-
-			footerHeight := int(float64(m.height) * 0.10)
-			if footerHeight < 5 {
-				footerHeight = 5
-			}
-
-			mainHeight := m.height - headerHeight - footerHeight - (3 * 2) // 3 sections with each 2 borders (top and bottom)
-			if mainHeight < 0 {
-				mainHeight = 0
-			}
-
-			visibleRows := mainHeight - 6 // Conservative estimate for headers
-			if visibleRows < 1 {
-				visibleRows = 1
-			}
-
 			if m.cursorSide >= m.sideOffset+visibleRows {
 				m.sideOffset = m.cursorSide - visibleRows + 1
 			}
@@ -719,6 +703,70 @@ func navigateDown(m model, steps int) (model, tea.Cmd) {
 	}
 
 	// Check to see if more has to be loaded
+	return loadMore(m)
+}
+
+func navigatePageUp(m model) model {
+	switch m.focus {
+	case focusMain:
+		if m.cursorMain > 0 {
+			if m.mainOffset == 0 {
+				m.cursorMain = 0
+			} else {
+				relativeCursorPos := m.cursorMain - m.mainOffset
+				m.mainOffset = max(0, m.mainOffset - _getMainVisibleRows(m))
+				m.cursorMain = max(0, m.mainOffset + relativeCursorPos)
+			}
+		}
+		if m.showSelection {
+			m = selectionScroller(m)
+		}
+	case focusSidebar:
+		if m.cursorSide > 0 {
+			_, visibleRows := _getSideLenAndRows(m)
+			if m.sideOffset == 0 {
+				m.cursorSide = 0
+			} else {
+				relativeCursorPos := m.cursorSide - m.sideOffset
+				m.sideOffset = max(0, m.sideOffset - visibleRows)
+				m.cursorSide = max(0, m.sideOffset + relativeCursorPos)
+			}
+		}
+	}
+	return m
+}
+
+func navigatePageDown(m model) (model, tea.Cmd) {
+	switch m.focus {
+	case focusMain:
+		listLen := _getMainListLength(m)
+		if listLen > 0 && m.cursorMain < listLen-1 {
+			visibleRows := _getMainVisibleRows(m)
+			maxOffset := max(0, listLen - visibleRows)
+			if m.mainOffset == maxOffset {
+				m.cursorMain = listLen - 1
+			} else {
+				relativeCursorPos := m.cursorMain - m.mainOffset
+				m.mainOffset = min(maxOffset, m.mainOffset + visibleRows)
+				m.cursorMain = min(listLen - 1, m.mainOffset + relativeCursorPos)
+			}
+		}
+		if m.showSelection {
+			m = selectionScroller(m)
+		}
+	case focusSidebar:
+		sideLen, visibleRows := _getSideLenAndRows(m)
+		if sideLen > 0 && m.cursorSide < sideLen-1 {
+			maxOffset := max(0, sideLen - visibleRows)
+			if m.sideOffset == maxOffset {
+				m.cursorSide = sideLen - 1
+			} else {
+				relativeCursorPos := m.cursorSide - m.sideOffset
+				m.sideOffset = min(maxOffset, m.sideOffset + visibleRows)
+				m.cursorSide = min(sideLen - 1, m.sideOffset + relativeCursorPos)
+			}
+		}
+	}
 	return loadMore(m)
 }
 

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -1361,11 +1361,24 @@ func mediaShowFavorites(m model, msg tea.Msg) (model, tea.Cmd) {
 		return typeInput(m, msg)
 	}
 
+	switch m.displayMode {
+	case displaySongs:
+		m.songsPrev = m.songs
+	case displayAlbums:
+		m.albumsPrev = m.albums
+	case displayArtist:
+		m.artistsPrev = m.artists
+	}
+	m.displayModePrev = m.displayMode
 	m.displayMode = displaySongs
 
 	m.songs = nil
 	m.viewMode = viewList
 	m.focus = focusMain
+	m.cursorMainPrev = m.cursorMain
+	m.cursorMain = 0
+	m.mainOffsetPrev = m.mainOffset
+	m.mainOffset = 0
 
 	return m, openLikedSongsCmd()
 }

--- a/internal/ui/update_messages.go
+++ b/internal/ui/update_messages.go
@@ -269,7 +269,7 @@ func (m model) handleStatus(msg statusMsg) (tea.Model, tea.Cmd) {
 
 	// Queue ended
 	if m.playerStatus.Path == "" || m.playerStatus.Path == "<nil>" || len(m.queue) == 0 {
-		m.queue = []api.Song{}
+		// m.queue = []api.Song{}
 		m.lastPlayedSongPath = ""
 
 		// Clear MRPIS

--- a/internal/ui/update_messages.go
+++ b/internal/ui/update_messages.go
@@ -230,9 +230,10 @@ func (m model) handleLoginResult(msg loginResultMsg) (tea.Model, tea.Cmd) {
 		player.SetVolume(api.AppConfig.App.Volume)
 	}
 
-	m.viewMode = viewList
-	m.focus = focusSearch
+	m.viewMode = viewQueue
+	m.focus = api.AppConfig.App.StartUpActive
 	m.loginErr = ""
+	m.playAfterLoad = api.AppConfig.App.PlayOnStartUp
 
 	return m, tea.Batch(
 		syncPlayerCmd(),

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -115,10 +115,7 @@ func (m model) BaseView() string {
 		Render(sidebarContent(m, mainHeight, sidebarWidth))
 
 	// MAIN VIEW
-	mainBorder := borderStyle
-	if m.focus == focusMain {
-		mainBorder = activeBorderStyle
-	}
+	mainBorder := m.buildMainViewBorder(mainWidth)
 
 	mainContent := ""
 	if m.loading &&
@@ -574,6 +571,41 @@ func mainArtistContent(m model, width int, height int) string {
 		subtleStyle.Render("  "+strings.Repeat("-", availableWidth)),
 		artistRows,
 	)
+}
+
+func (m model) buildMainViewBorder(width int) lipgloss.Style {
+	base := borderStyle
+	if m.focus == focusMain {
+		base = activeBorderStyle
+	}
+
+	listLen := 0
+	switch m.displayMode {
+	case displaySongs:
+		if m.viewMode == viewQueue {
+			listLen = len(m.queue)
+		} else {
+			listLen = len(m.songs)
+		}
+	case displayAlbums:
+		listLen = len(m.albums)
+	case displayArtist:
+		listLen = len(m.artists)
+	}
+
+	if listLen > 0 {
+		listStatus := fmt.Sprintf(" %d/%d ", m.cursorMain + 1, listLen)
+
+		b := lipgloss.RoundedBorder()
+		bLen := max(width - len(listStatus), 0)
+		bLeft := bLen / 2
+		b.Bottom = strings.Repeat("─", bLeft ) +
+			listStatus + strings.Repeat("─", bLen - bLeft)
+
+		return base.Border(b)
+	}
+
+	return base
 }
 
 // Generate the footer

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1187,6 +1187,8 @@ func helpViewContent() string {
 		line(keys(api.AppConfig.Keybinds.Navigation.Select), "Select"),
 		line(keys(api.AppConfig.Keybinds.Navigation.ToggleSelection), "Toggle Selection"),
 		line(keys(api.AppConfig.Keybinds.Navigation.PlayShuffled), "Start shuffled"),
+		line(keys(api.AppConfig.Keybinds.Navigation.GoPageUp), "Go page up"),
+		line(keys(api.AppConfig.Keybinds.Navigation.GoPageDown), "Go page down"),
 		line(keys(api.AppConfig.Keybinds.Navigation.GoHalfPageUp), "Go half page up"),
 		line(keys(api.AppConfig.Keybinds.Navigation.GoHalfPageDown), "Go half page down"),
 	)


### PR DESCRIPTION
This PR introduces dedicated Page Up and Page Down controls.

Added dedicated handlers: Introduce navigatePageUp and navigatePageDown functions for proper whole-page scrolling.

Clean up redundant code: Remove a duplicated m.cursorSide < m.sideOffset boundary check in the sidebar logic in ui/update_keys.go navigateUp