### PR TITLE
fix(api): handle error in SubsonicGetLyrics function

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -423,6 +423,7 @@ func SubsonicGetLyrics(ID string) ([]StructuredLyrics, error) {
 	data, err := subsonicGET("/getLyricsBySongId", params)
 	if err != nil {
 		log.Printf("[ERROR] API Error in GetLyrics: %s", err)
+		return nil, err
 	}
 
 	return data.Response.LyricsList.StructuredLyrics, nil


### PR DESCRIPTION
Sometimes app panics because of no proper error handling in `SubSonicGetLyrics`, stacktrace:
```
goroutine 150 [running]:
runtime/debug.Stack()
        /usr/lib/go/src/runtime/debug/stack.go:26 +0x5e
runtime/debug.PrintStack()
        /usr/lib/go/src/runtime/debug/stack.go:18 +0x13
github.com/charmbracelet/bubbletea.(*Program).recoverFromGoPanic(0x25095d85a640, {0x946120, 0xeb5a80})
        /home/phoenixofhp/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.10/tea.go:859 +0xab
github.com/charmbracelet/bubbletea.(*Program).execBatchMsg.func2.1()
        /home/phoenixofhp/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.10/tea.go:555 +0x35
panic({0x946120?, 0xeb5a80?})
        /usr/lib/go/src/runtime/panic.go:860 +0x13a
github.com/MattiaPun/SubTUI/v2/internal/api.SubsonicGetLyrics({0x25095dc8abd0, 0x16})
        /home/phoenixofhp/SubTUI/internal/api/api.go:428 +0x1e0
github.com/MattiaPun/SubTUI/v2/internal/ui.model.handleStatus.getLyricsCmd.func5()
        /home/phoenixofhp/SubTUI/internal/ui/cmds_api.go:227 +0x25
github.com/charmbracelet/bubbletea.(*Program).execBatchMsg.func2()
        /home/phoenixofhp/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.10/tea.go:560 +0xab
created by github.com/charmbracelet/bubbletea.(*Program).execBatchMsg in goroutine 147
        /home/phoenixofhp/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.10/tea.go:549 +0x106
exit status 1
``` 