### PR TITLE
feat: add mouse wheel scrolling and DJ/Radio mode

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -415,6 +415,37 @@ func SubsonicCreateShare(ids []string) (string, error) {
 
 }
 
+func SubsonicGetSimilarSongs(id string, count int) ([]Song, error) {
+	params := url.Values{
+		"id":    {id},
+		"count": {strconv.Itoa(count)},
+	}
+
+	data, err := subsonicGET("/getSimilarSongs2", params)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.Response.SimilarSongs2.Song, nil
+}
+
+func SubsonicGetRandomSongs(count int, genre string) ([]Song, error) {
+	params := url.Values{
+		"size": {strconv.Itoa(count)},
+	}
+
+	if genre != "" {
+		params.Set("genre", genre)
+	}
+
+	data, err := subsonicGET("/getRandomSongs", params)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.Response.RandomSongs.Song, nil
+}
+
 func SubsonicGetLyrics(ID string) ([]StructuredLyrics, error) {
 	params := url.Values{
 		"id": {ID},

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -446,6 +446,17 @@ func SubsonicGetRandomSongs(count int, genre string) ([]Song, error) {
 	return data.Response.RandomSongs.Song, nil
 }
 
+func SubsonicGetSong(ID string) (*Song, error) {
+	params := url.Values{
+		"id": {ID},
+	}
+	data, err := subsonicGET("/getSong", params)
+	if err != nil {
+		return nil, err
+	}
+	return &data.Response.SongDetail, nil
+}
+
 func SubsonicGetLyrics(ID string) ([]StructuredLyrics, error) {
 	params := url.Values{
 		"id": {ID},

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -177,6 +177,8 @@ type MediaKeybinds struct {
 	VolumeUp          []string `toml:"volume_up"`
 	VolumeDown        []string `toml:"volume_down"`
 	ToggleMediaPlayer []string `toml:"toggle_media_player"`
+	DjToggle          []string `toml:"dj_toggle"`
+	DjCycleMood       []string `toml:"dj_cycle_mood"`
 }
 
 type QueueKeybinds struct {

--- a/internal/api/config.toml
+++ b/internal/api/config.toml
@@ -103,6 +103,8 @@ max_rating = 0 # Exclude songs with a rating less than or equal to this number (
   volume_up           = ['v']
   volume_down         = ['V']
   toggle_media_player = ['m', 'M']
+  dj_toggle           = ['z']
+  dj_cycle_mood       = ['Z']
 
   [keybinds.queue]
   toggle_queue_view = ['Q']

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -44,6 +44,12 @@ type SubsonicResponse struct {
 		LyricsList struct {
 			StructuredLyrics []StructuredLyrics `json:"structuredLyrics"`
 		} `json:"lyricsList"`
+		SimilarSongs2 struct {
+			Song []Song `json:"song"`
+		} `json:"similarSongs2"`
+		RandomSongs struct {
+			Song []Song `json:"song"`
+		} `json:"randomSongs"`
 	} `json:"subsonic-response"`
 }
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -44,6 +44,7 @@ type SubsonicResponse struct {
 		LyricsList struct {
 			StructuredLyrics []StructuredLyrics `json:"structuredLyrics"`
 		} `json:"lyricsList"`
+		SongDetail      Song   `json:"song"`
 		SimilarSongs2 struct {
 			Song []Song `json:"song"`
 		} `json:"similarSongs2"`

--- a/internal/integration/common.go
+++ b/internal/integration/common.go
@@ -8,6 +8,7 @@ type Metadata struct {
 	Position float64
 	ImageURL string
 	Rating   float64
+	TrackID  string
 }
 
 type Status string
@@ -24,6 +25,18 @@ type NextSongMsg struct{}
 type PreviousSongMsg struct{}
 type SetPositionMsg struct {
 	Position int64
+}
+
+type AddTrackRequestMsg struct {
+	URI          string
+	AfterTrack   string
+	SetAsCurrent bool
+}
+type RemoveTrackRequestMsg struct {
+	TrackID string
+}
+type GoToRequestMsg struct {
+	TrackID string
 }
 
 func (m Metadata) LengthInMicroseconds() int64 {

--- a/internal/integration/media_darwin.go
+++ b/internal/integration/media_darwin.go
@@ -15,8 +15,12 @@ func (ins *Instance) GetStatus() string {
 	return "Stopped"
 }
 
-func (ins *Instance) UpdateStatus(status string)    {}
-func (ins *Instance) UpdatePosition(position int64) {}
-func (ins *Instance) UpdateMetadata(meta Metadata)  {}
-func (ins *Instance) ClearMetadata()                {}
-func (ins *Instance) Close()                        {}
+func (ins *Instance) UpdateStatus(status string)     {}
+func (ins *Instance) UpdatePosition(position int64)  {}
+func (ins *Instance) UpdateMetadata(meta Metadata)   {}
+func (ins *Instance) ClearMetadata()                 {}
+func (ins *Instance) Close()                         {}
+func (ins *Instance) ReplaceTrackList(trackIDs []string, metadatas map[string]map[string]interface{}, currentTrack string) {}
+func (ins *Instance) EmitTrackAdded(trackIDs []string, trackID string, metadata map[string]interface{}, afterTrack string)  {}
+func (ins *Instance) EmitTrackRemoved(trackIDs []string, trackID string)                                                   {}
+func (ins *Instance) EmitTrackMetadataChanged(trackID string, metadata map[string]interface{})                              {}

--- a/internal/integration/media_dbus.go
+++ b/internal/integration/media_dbus.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"log"
+	"sync"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/godbus/dbus/v5"
@@ -11,8 +12,10 @@ import (
 )
 
 type Instance struct {
-	props *prop.Properties
-	conn  *dbus.Conn
+	props      *prop.Properties
+	conn       *dbus.Conn
+	trackMetas map[dbus.ObjectPath]map[string]interface{}
+	mu         sync.RWMutex
 }
 
 func Init(p *tea.Program) *Instance {
@@ -21,9 +24,12 @@ func Init(p *tea.Program) *Instance {
 		return nil
 	}
 
-	ins := &Instance{conn: conn}
+	ins := &Instance{
+		conn:       conn,
+		trackMetas: make(map[dbus.ObjectPath]map[string]interface{}),
+	}
 
-	mp2 := &MediaPlayer2{Program: p}
+	mp2 := &MediaPlayer2{Program: p, Instance: ins}
 	err = conn.Export(mp2, "/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.Player")
 	if err != nil {
 		log.Printf("MPRIS Export Error: %v", err)
@@ -35,12 +41,18 @@ func Init(p *tea.Program) *Instance {
 		log.Printf("MPRIS Root Export Error: %v", err)
 	}
 
+	err = conn.Export(mp2, "/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.TrackList")
+	if err != nil {
+		log.Printf("MPRIS TrackList Export Error: %v", err)
+	}
+
 	ins.props, _ = prop.Export(
 		conn,
 		"/org/mpris/MediaPlayer2",
 		map[string]map[string]*prop.Prop{
-			"org.mpris.MediaPlayer2":        rootProps,
-			"org.mpris.MediaPlayer2.Player": playerProps,
+			"org.mpris.MediaPlayer2":          rootProps,
+			"org.mpris.MediaPlayer2.Player":   playerProps,
+			"org.mpris.MediaPlayer2.TrackList": trackListProps,
 		},
 	)
 
@@ -98,11 +110,17 @@ func (ins *Instance) ClearMetadata() {
 		return
 	}
 
-	emptyMeta := make(map[string]dbus.Variant)
-	emptyMeta["mpris:trackid"] = dbus.MakeVariant(dbus.ObjectPath("/org/mpris/MediaPlayer2/TrackList/NoTrack"))
+	emptyMeta := map[string]dbus.Variant{
+		"mpris:trackid": dbus.MakeVariant(dbus.ObjectPath(NoTrack)),
+	}
+
+	signalMeta := map[string]interface{}{
+		"mpris:trackid": dbus.ObjectPath(NoTrack),
+	}
 
 	_ = ins.props.Set("org.mpris.MediaPlayer2.Player", "Metadata", dbus.MakeVariant(emptyMeta))
 	_ = ins.props.Set("org.mpris.MediaPlayer2.Player", "PlaybackStatus", dbus.MakeVariant("Stopped"))
+	ins.EmitTrackMetadataChanged(NoTrack, signalMeta)
 }
 
 func (ins *Instance) Close() {

--- a/internal/integration/media_dbus_methods.go
+++ b/internal/integration/media_dbus_methods.go
@@ -8,7 +8,8 @@ import (
 )
 
 type MediaPlayer2 struct {
-	Program *tea.Program
+	Program  *tea.Program
+	Instance *Instance
 }
 
 func (m *MediaPlayer2) Play() *dbus.Error {

--- a/internal/integration/media_dbus_props.go
+++ b/internal/integration/media_dbus_props.go
@@ -35,15 +35,19 @@ var playerProps = map[string]*prop.Prop{
 var rootProps = map[string]*prop.Prop{
 	"CanQuit":             newProp(true, nil),
 	"CanRaise":            newProp(false, nil),
-	"HasTrackList":        newProp(false, nil),
+	"HasTrackList":        newProp(true, nil),
 	"Identity":            newProp("SubTUI", nil),
 	"SupportedUriSchemes": newProp([]string{}, nil),
 	"SupportedMimeTypes":  newProp([]string{}, nil),
 }
 
 func (m Metadata) ToMap() map[string]interface{} {
+	trackID := dbus.ObjectPath(NoTrack)
+	if m.TrackID != "" {
+		trackID = dbus.ObjectPath(m.TrackID)
+	}
 	return map[string]interface{}{
-		"mpris:trackid":     dbus.ObjectPath("/org/mpris/MediaPlayer2/TrackList/NoTrack"),
+		"mpris:trackid":     trackID,
 		"mpris:length":      m.LengthInMicroseconds(),
 		"xesam:title":       m.Title,
 		"xesam:artist":      []string{m.Artist},

--- a/internal/integration/media_dbus_tracklist.go
+++ b/internal/integration/media_dbus_tracklist.go
@@ -1,0 +1,157 @@
+//go:build linux || freebsd
+
+package integration
+
+import (
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/prop"
+)
+
+const NoTrack = "/org/mpris/MediaPlayer2/TrackList/NoTrack"
+
+var trackListProps = map[string]*prop.Prop{
+	"Tracks": {
+		Value:    []dbus.ObjectPath{},
+		Writable: true,
+		Emit:     prop.EmitFalse,
+	},
+	"CanEditTracks": {
+		Value:    true,
+		Writable: true,
+		Emit:     prop.EmitTrue,
+	},
+}
+
+func (m *MediaPlayer2) GetTracksMetadata(trackIds []dbus.ObjectPath) (map[dbus.ObjectPath]map[string]interface{}, *dbus.Error) {
+	if m.Instance == nil {
+		return nil, nil
+	}
+	m.Instance.mu.RLock()
+	defer m.Instance.mu.RUnlock()
+	result := make(map[dbus.ObjectPath]map[string]interface{})
+	for _, id := range trackIds {
+		if meta, ok := m.Instance.trackMetas[id]; ok {
+			result[id] = meta
+		}
+	}
+	return result, nil
+}
+
+func (m *MediaPlayer2) AddTrack(uri string, afterTrack dbus.ObjectPath, setAsCurrent bool) *dbus.Error {
+	if m.Program != nil {
+		m.Program.Send(AddTrackRequestMsg{
+			URI:          uri,
+			AfterTrack:   string(afterTrack),
+			SetAsCurrent: setAsCurrent,
+		})
+	}
+	return nil
+}
+
+func (m *MediaPlayer2) RemoveTrack(trackId dbus.ObjectPath) *dbus.Error {
+	if m.Program != nil {
+		m.Program.Send(RemoveTrackRequestMsg{
+			TrackID: string(trackId),
+		})
+	}
+	return nil
+}
+
+func (m *MediaPlayer2) GoTo(trackId dbus.ObjectPath) *dbus.Error {
+	if m.Program != nil {
+		m.Program.Send(GoToRequestMsg{
+			TrackID: string(trackId),
+		})
+	}
+	return nil
+}
+
+func toDBusObjectPaths(ids []string) []dbus.ObjectPath {
+	paths := make([]dbus.ObjectPath, len(ids))
+	for i, id := range ids {
+		paths[i] = dbus.ObjectPath(id)
+	}
+	return paths
+}
+
+func toDBusMetaMap(metas map[string]map[string]interface{}) map[dbus.ObjectPath]map[string]interface{} {
+	result := make(map[dbus.ObjectPath]map[string]interface{}, len(metas))
+	for k, v := range metas {
+		result[dbus.ObjectPath(k)] = v
+	}
+	return result
+}
+
+func (ins *Instance) ReplaceTrackList(trackIDs []string, metadatas map[string]map[string]interface{}, currentTrack string) {
+	if ins == nil || ins.conn == nil {
+		return
+	}
+
+	dbusIDs := toDBusObjectPaths(trackIDs)
+	dbusMetas := toDBusMetaMap(metadatas)
+	dbusCurrent := dbus.ObjectPath(currentTrack)
+
+	ins.mu.Lock()
+	ins.trackMetas = dbusMetas
+	ins.mu.Unlock()
+
+	_ = ins.props.Set("org.mpris.MediaPlayer2.TrackList", "Tracks", dbus.MakeVariant(dbusIDs))
+	_ = ins.conn.Emit("/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.TrackList.TrackListReplaced", dbusIDs, dbusCurrent)
+}
+
+func (ins *Instance) EmitTrackAdded(trackIDs []string, trackID string, metadata map[string]interface{}, afterTrack string) {
+	if ins == nil || ins.conn == nil {
+		return
+	}
+
+	dbusIDs := toDBusObjectPaths(trackIDs)
+	dbusID := dbus.ObjectPath(trackID)
+	dbusAfter := dbus.ObjectPath(afterTrack)
+
+	ins.mu.Lock()
+	ins.trackMetas[dbusID] = metadata
+	ins.mu.Unlock()
+
+	_ = ins.props.Set("org.mpris.MediaPlayer2.TrackList", "Tracks", dbus.MakeVariant(dbusIDs))
+	_ = ins.conn.Emit("/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.TrackList.TrackAdded", toVariantMap(metadata), dbusAfter)
+}
+
+func (ins *Instance) EmitTrackRemoved(trackIDs []string, trackID string) {
+	if ins == nil || ins.conn == nil {
+		return
+	}
+
+	dbusIDs := toDBusObjectPaths(trackIDs)
+	dbusID := dbus.ObjectPath(trackID)
+
+	ins.mu.Lock()
+	delete(ins.trackMetas, dbusID)
+	ins.mu.Unlock()
+
+	_ = ins.props.Set("org.mpris.MediaPlayer2.TrackList", "Tracks", dbus.MakeVariant(dbusIDs))
+	_ = ins.conn.Emit("/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.TrackList.TrackRemoved", dbusID)
+}
+
+func (ins *Instance) EmitTrackMetadataChanged(trackID string, metadata map[string]interface{}) {
+	if ins == nil || ins.conn == nil {
+		return
+	}
+
+	dbusID := dbus.ObjectPath(trackID)
+
+	ins.mu.Lock()
+	ins.trackMetas[dbusID] = metadata
+	ins.mu.Unlock()
+
+	_ = ins.conn.Emit("/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.TrackList.TrackMetadataChanged", dbusID, toVariantMap(metadata))
+}
+
+func toVariantMap(meta map[string]interface{}) map[string]dbus.Variant {
+	result := make(map[string]dbus.Variant, len(meta))
+	for k, v := range meta {
+		result[k] = dbus.MakeVariant(v)
+	}
+	return result
+}
+
+

--- a/internal/ui/dj.go
+++ b/internal/ui/dj.go
@@ -1,0 +1,193 @@
+package ui
+
+import (
+	"math/rand"
+	"strings"
+
+	"github.com/MattiaPun/SubTUI/v2/internal/api"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+var moodGenres = map[int][]string{
+	DjMoodChill:  {"ambient", "chillout", "downtempo", "lounge", "jazz", "classical", "acoustic", "folk", "lo-fi", "soul", "r&b"},
+	DjMoodEnergy: {"rock", "metal", "punk", "electronic", "dance", "hip-hop", "pop", "alternative", "indie", "techno", "house"},
+	DjMoodFocus:  {"classical", "ambient", "instrumental", "jazz", "post-rock", "minimal", "cinematic", "soundtrack"},
+}
+
+type djRefillResultMsg struct {
+	songs []api.Song
+}
+
+func (m model) djToggle() model {
+	m.djEnabled = !m.djEnabled
+	if m.djEnabled {
+		m.djMood = DjMoodAny
+		if len(m.queue) > 0 && m.queueIndex < len(m.queue) {
+			m.djSeed = m.queue[m.queueIndex].ID
+		}
+	} else {
+		m.djHistory = make(map[string]bool)
+	}
+	return m
+}
+
+func (m model) djCycleMood() model {
+	if !m.djEnabled {
+		return m
+	}
+	m.djMood = (m.djMood + 1) % len(DjMoodLabels)
+	return m
+}
+
+func (m model) djRefillIfNeeded() tea.Cmd {
+	if !m.djEnabled {
+		return nil
+	}
+	remaining := len(m.queue) - m.queueIndex - 1
+	if remaining > 5 {
+		return nil
+	}
+	return m.djRefillCmd()
+}
+
+func (m model) djRefillCmd() tea.Cmd {
+	seedID := m.djSeed
+	if seedID == "" && len(m.queue) > 0 && m.queueIndex < len(m.queue) {
+		seedID = m.queue[m.queueIndex].ID
+	}
+
+	return func() tea.Msg {
+		if seedID == "" {
+			songs, err := api.SubsonicGetRandomSongs(20, "")
+			if err != nil {
+				return djRefillResultMsg{}
+			}
+			return djRefillResultMsg{songs: songs}
+		}
+
+		similar, err := api.SubsonicGetSimilarSongs(seedID, 50)
+		if err != nil {
+			similar = nil
+		}
+
+		if len(similar) < 15 {
+			random, err := api.SubsonicGetRandomSongs(30, "")
+			if err == nil {
+				seen := make(map[string]bool, len(similar))
+				for _, s := range similar {
+					seen[s.ID] = true
+				}
+				for _, s := range random {
+					if !seen[s.ID] {
+						similar = append(similar, s)
+						seen[s.ID] = true
+					}
+				}
+			}
+		}
+
+		return djRefillResultMsg{songs: similar}
+	}
+}
+
+func (m model) handleDjRefill(msg djRefillResultMsg) (tea.Model, tea.Cmd) {
+	if len(msg.songs) == 0 {
+		return m, nil
+	}
+
+	type weighted struct {
+		song   api.Song
+		weight float64
+	}
+	var candidates []weighted
+
+	for _, song := range msg.songs {
+		w := 1.0
+
+		if m.djSeed != "" && song.ArtistID != "" {
+			var seedArtistID string
+			if len(m.queue) > 0 && m.queueIndex < len(m.queue) {
+				seedArtistID = m.queue[m.queueIndex].ArtistID
+				if song.ArtistID == seedArtistID {
+					w *= 3.0
+				}
+			}
+		}
+
+		w *= 1.0 + float64(song.Rating)*0.5
+
+		if song.Filtered || song.ID == "" {
+			w = 0
+		}
+
+		if m.djHistory[song.ID] {
+			w *= 0.05
+		}
+
+		if m.djMood != DjMoodAny {
+			genre := strings.ToLower(song.Genre)
+			validGenres := moodGenres[m.djMood]
+			match := false
+			for _, g := range validGenres {
+				if strings.Contains(genre, g) {
+					match = true
+					break
+				}
+			}
+			if !match {
+				w *= 0.3
+			}
+		}
+
+		if w > 0 {
+			candidates = append(candidates, weighted{song, w})
+		}
+	}
+
+	if len(candidates) == 0 {
+		return m, nil
+	}
+
+	totalWeight := 0.0
+	for _, c := range candidates {
+		totalWeight += c.weight
+	}
+
+	count := 15
+	if count > len(candidates) {
+		count = len(candidates)
+	}
+	selected := make([]api.Song, 0, count)
+	selectedIDs := make(map[string]bool)
+
+	for len(selected) < count {
+		pick := rand.Float64() * totalWeight
+		cumulative := 0.0
+		found := -1
+		for i, c := range candidates {
+			if selectedIDs[c.song.ID] {
+				continue
+			}
+			cumulative += c.weight
+			if pick <= cumulative {
+				found = i
+				break
+			}
+		}
+		if found == -1 {
+			break
+		}
+		s := candidates[found].song
+		selected = append(selected, s)
+		selectedIDs[s.ID] = true
+		m.djHistory[s.ID] = true
+		if len(selectedIDs) >= len(candidates) {
+			break
+		}
+	}
+
+	m.queue = append(m.queue, selected...)
+	m.syncNextSong()
+
+	return m, nil
+}

--- a/internal/ui/dj.go
+++ b/internal/ui/dj.go
@@ -187,6 +187,14 @@ func (m model) handleDjRefill(msg djRefillResultMsg) (tea.Model, tea.Cmd) {
 	}
 
 	m.queue = append(m.queue, selected...)
+
+	// DJ-дозаповнення має потрапити в MPRIS TrackList: перегенеровуємо
+	// id (ReplaceTrackList згенерує TrackListReplaced) і пере-пушимо
+	// metadata поточного треку, бо його старий id став невалідним.
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
+	m.pushCurrentMetadata()
+
 	m.syncNextSong()
 
 	return m, nil

--- a/internal/ui/init.go
+++ b/internal/ui/init.go
@@ -35,6 +35,7 @@ func InitialModel() model {
 		filterMode:         filterSongs,
 		displayMode:        displaySongs,
 		starredMap:         make(map[string]bool),
+		djHistory:          make(map[string]bool),
 		lastPlayedSongPath: "",
 		loginInputs:        initialLoginInputs(),
 		lastKey:            "",

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -100,6 +100,12 @@ type model struct {
 	selectionAnchor int
 	selectionMap    map[int]bool
 
+	// DJ state
+	djEnabled  bool
+	djMood     int
+	djSeed     string
+	djHistory  map[string]bool
+
 	// Mouse state
 	lastClickTime time.Time
 	lastClickId   string

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -63,9 +63,11 @@ type model struct {
 	discordInstance *integration.DiscordInstance
 
 	// Queue System
-	queue      []api.Song
-	queueIndex int
-	loopMode   int
+	queue          []api.Song
+	queueTrackIDs  []string
+	trackIDCounter int64
+	queueIndex     int
+	loopMode       int
 
 	// Stars
 	starredMap map[string]bool

--- a/internal/ui/queue.go
+++ b/internal/ui/queue.go
@@ -48,6 +48,7 @@ func (m *model) playQueueIndex(index int, startPaused bool) tea.Cmd {
 	return tea.Batch(
 		playCmd,
 		m.savePlayQueue(),
+		m.djRefillIfNeeded(),
 	)
 }
 

--- a/internal/ui/queue.go
+++ b/internal/ui/queue.go
@@ -21,6 +21,7 @@ func (m *model) playQueueIndex(index int, startPaused bool) tea.Cmd {
 	}
 
 	m.queueIndex = index
+	m.djSeed = m.queue[index].ID
 	song := m.queue[m.queueIndex]
 
 	playCmd := func() tea.Msg {

--- a/internal/ui/queue.go
+++ b/internal/ui/queue.go
@@ -2,9 +2,11 @@ package ui
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/MattiaPun/SubTUI/v2/internal/api"
+	"github.com/MattiaPun/SubTUI/v2/internal/integration"
 	"github.com/MattiaPun/SubTUI/v2/internal/player"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -104,6 +106,11 @@ func (m *model) setQueue(startIndex int) tea.Cmd {
 	}
 
 	m.queue = newQueue
+	result := m.generateTrackIDs()
+	m.queueTrackIDs = result.queueTrackIDs
+	m.trackIDCounter = result.trackIDCounter
+	m.queueIndex = newStartIndex
+	m.syncTrackListToDBus()
 	return m.playQueueIndex(newStartIndex, false)
 }
 
@@ -119,6 +126,47 @@ func (m *model) savePlayQueue() tea.Cmd {
 	}
 
 	return savePlayQueueCmd(ids, currentID)
+}
+
+func (m model) generateTrackIDs() model {
+	m.queueTrackIDs = make([]string, len(m.queue))
+	for i := range m.queue {
+		m.trackIDCounter++
+		m.queueTrackIDs[i] = fmt.Sprintf("/org/mpris/MediaPlayer2/TrackList/%d", m.trackIDCounter)
+	}
+	return m
+}
+
+func (m model) buildTrackMetadatas() map[string]map[string]interface{} {
+	metas := make(map[string]map[string]interface{}, len(m.queue))
+	for i := range m.queue {
+		song := m.queue[i]
+		meta := integration.Metadata{
+			TrackID:  m.queueTrackIDs[i],
+			Title:    song.Title,
+			Artist:   song.Artist,
+			Album:    song.Album,
+			Duration: float64(song.Duration),
+			ImageURL: api.SubsonicCoverArtUrl(song.ID, 500),
+			Rating:   math.Round(float64(song.Rating*10)) / 10,
+		}
+		metas[m.queueTrackIDs[i]] = meta.ToMap()
+	}
+	return metas
+}
+
+func (m *model) currentTrackID() string {
+	if m.queueIndex >= 0 && m.queueIndex < len(m.queueTrackIDs) {
+		return m.queueTrackIDs[m.queueIndex]
+	}
+	return integration.NoTrack
+}
+
+func (m *model) syncTrackListToDBus() {
+	if m.dbusInstance == nil {
+		return
+	}
+	m.dbusInstance.ReplaceTrackList(m.queueTrackIDs, m.buildTrackMetadatas(), m.currentTrackID())
 }
 
 func getSelectedSongs(m model) []api.Song {

--- a/internal/ui/queue.go
+++ b/internal/ui/queue.go
@@ -173,6 +173,29 @@ func (m *model) syncTrackListToDBus() {
 	m.dbusInstance.ReplaceTrackList(m.queueTrackIDs, m.buildTrackMetadatas(), m.currentTrackID())
 }
 
+// Пере-пушить metadata поточного треку — після generateTrackIDs() старе
+// mpris:trackid у Player.Metadata інвалідне (id перегенеровуються всі),
+// тому без цього клієнти (Quickshell-плейліст) втрачають підсвітку треку.
+func (m *model) pushCurrentMetadata() {
+	if m.dbusInstance == nil {
+		return
+	}
+	if m.queueIndex < 0 || m.queueIndex >= len(m.queue) {
+		m.dbusInstance.UpdateMetadata(integration.Metadata{TrackID: integration.NoTrack})
+		return
+	}
+	song := m.queue[m.queueIndex]
+	m.dbusInstance.UpdateMetadata(integration.Metadata{
+		TrackID:  m.currentTrackID(),
+		Title:    song.Title,
+		Artist:   song.Artist,
+		Album:    song.Album,
+		Duration: float64(song.Duration),
+		ImageURL: api.SubsonicCoverArtUrl(song.ID, 500),
+		Rating:   math.Round(float64(song.Rating*10)) / 10,
+	})
+}
+
 func getSelectedSongs(m model) []api.Song {
 	if m.focus == focusMain && cursorInBounds(m) {
 		switch m.viewMode {

--- a/internal/ui/types.go
+++ b/internal/ui/types.go
@@ -33,6 +33,20 @@ const (
 )
 
 const (
+	DjMoodAny    = 0
+	DjMoodChill  = 1
+	DjMoodEnergy = 2
+	DjMoodFocus  = 3
+)
+
+var DjMoodLabels = map[int]string{
+	DjMoodAny:    "Any",
+	DjMoodChill:  "Chill",
+	DjMoodEnergy: "Energy",
+	DjMoodFocus:  "Focus",
+}
+
+const (
 	loginPassword = iota
 	loginPasswordHashed
 	loginApi

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -82,6 +82,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case SetDiscordMsg:
 		return m.handleSetDiscord(msg)
 
+	case djRefillResultMsg:
+		return m.handleDjRefill(msg)
+
 	}
 
 	return m, cmd

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -79,6 +79,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case integration.SetPositionMsg:
 		return m.handleIntegrationSetPosition(msg)
 
+	case integration.AddTrackRequestMsg:
+		return m.handleAddTrackRequest(msg)
+
+	case integration.RemoveTrackRequestMsg:
+		return m.handleRemoveTrackRequest(msg)
+
+	case integration.GoToRequestMsg:
+		return m.handleGoToRequest(msg)
+
 	case SetDiscordMsg:
 		return m.handleSetDiscord(msg)
 

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -218,6 +218,15 @@ func (m model) handlesKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return mediaToggleMediaPlayer(m), nil
 	}
 
+	if keyMatches(key, api.AppConfig.Keybinds.Media.DjToggle) {
+		m = m.djToggle()
+		return m, m.djRefillIfNeeded()
+	}
+
+	if keyMatches(key, api.AppConfig.Keybinds.Media.DjCycleMood) {
+		return m.djCycleMood(), nil
+	}
+
 	// QUEUE KEYBINDS
 	if keyMatches(key, api.AppConfig.Keybinds.Queue.ToggleQueueView) {
 		return toggleQueue(m), nil

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -973,6 +973,9 @@ func mediaQueueNext(m model) (model, tea.Cmd) {
 	// Sync MPV's Queue
 	m.syncNextSong()
 
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
+
 	return m, cmd
 }
 
@@ -1006,6 +1009,9 @@ func mediaQueueLast(m model) (model, tea.Cmd) {
 
 	// Sync MPV's Queue
 	m.syncNextSong()
+
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
 
 	return m, cmd
 }
@@ -1068,6 +1074,9 @@ func mediaDeleteSongFromQueue(m model) model {
 	// Sync MPV's Queue
 	m.syncNextSong()
 
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
+
 	return m
 }
 
@@ -1083,6 +1092,9 @@ func mediaClearQueue(m model) model {
 
 	// Sync MPV's Queue
 	m.syncNextSong()
+
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
 
 	return m
 }
@@ -1138,6 +1150,8 @@ func mediaSongUpQueue(m model) model {
 	}
 
 	m.syncNextSong()
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
 	return m
 }
 
@@ -1192,6 +1206,8 @@ func mediaSongDownQueue(m model) model {
 	}
 
 	m.syncNextSong()
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
 	return m
 }
 
@@ -1275,6 +1291,9 @@ func mediaShuffle(m model) model {
 
 	// Sync MPV's Queue
 	m.syncNextSong()
+
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
 
 	return m
 }

--- a/internal/ui/update_messages.go
+++ b/internal/ui/update_messages.go
@@ -41,6 +41,47 @@ func (m model) handleWindowResize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if msg.Action == tea.MouseActionPress {
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			if m.showMediaPlayer {
+				return lyricsUp(m), nil
+			}
+			if m.showPlaylists || m.showRating {
+				if m.cursorPopup > 0 {
+					m.cursorPopup--
+				}
+				return m, nil
+			}
+			if m.focus == focusMain || m.focus == focusSidebar {
+				return navigateUp(m, 3), nil
+			}
+			return m, nil
+
+		case tea.MouseButtonWheelDown:
+			if m.showMediaPlayer {
+				return lyricsDown(m), nil
+			}
+			if m.showPlaylists {
+				if m.cursorPopup < len(m.playlists)-1 {
+					m.cursorPopup++
+				}
+				return m, nil
+			}
+			if m.showRating {
+				if m.cursorPopup < 5 {
+					m.cursorPopup++
+				}
+				return m, nil
+			}
+			if m.focus == focusMain || m.focus == focusSidebar {
+				return navigateDown(m, 3)
+			}
+			return m, nil
+		}
+		return m, nil
+	}
+
 	if msg.Action != tea.MouseActionRelease || msg.Button != tea.MouseButtonLeft {
 		return m, nil
 	}

--- a/internal/ui/update_messages.go
+++ b/internal/ui/update_messages.go
@@ -591,6 +591,10 @@ func (m model) handleIntegrationStop() (tea.Model, tea.Cmd) {
 	m.queue = nil
 	player.Stop()
 
+	// Прибираємо TrackList на D-Bus, поки інтеграція перепідключається
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
+
 	return m, nil
 }
 

--- a/internal/ui/update_messages.go
+++ b/internal/ui/update_messages.go
@@ -359,6 +359,7 @@ func (m model) handleStatus(msg statusMsg) (tea.Model, tea.Cmd) {
 
 		// Setup metadata
 		metadata := integration.Metadata{
+			TrackID:  m.currentTrackID(),
 			Title:    currentSong.Title,
 			Artist:   currentSong.Artist,
 			Album:    currentSong.Album,
@@ -539,6 +540,8 @@ func (m model) handleShuffledSongs(msg shuffledSongsMsg) (tea.Model, tea.Cmd) {
 
 	m.queue = shuffledQueue
 	m.loading = false
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
 
 	return m, m.playQueueIndex(0, false)
 }
@@ -565,6 +568,9 @@ func (m model) handlePlayQueueResult(msg playQueueResultMsg) (tea.Model, tea.Cmd
 			m.queueIndex = index
 		}
 	}
+
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
 
 	return m, m.playQueueIndex(m.queueIndex, true)
 }
@@ -610,4 +616,97 @@ func (m model) handleIntegrationSetPosition(msg integration.SetPositionMsg) (tea
 func (m model) handleSetDiscord(msg SetDiscordMsg) (tea.Model, tea.Cmd) {
 	m.discordInstance = msg.Instance
 	return m, nil
+}
+
+func (m model) handleAddTrackRequest(msg integration.AddTrackRequestMsg) (tea.Model, tea.Cmd) {
+	songID := extractSongIDFromURI(msg.URI)
+	if songID == "" {
+		return m, nil
+	}
+
+	song, err := api.SubsonicGetSong(songID)
+	if err != nil || song.ID == "" {
+		return m, nil
+	}
+
+	insertIndex := len(m.queue)
+	if msg.AfterTrack != integration.NoTrack {
+		for i, tid := range m.queueTrackIDs {
+			if tid == msg.AfterTrack {
+				insertIndex = i + 1
+				break
+			}
+		}
+	} else {
+		insertIndex = 0
+	}
+
+	tail := append([]api.Song{}, m.queue[insertIndex:]...)
+	m.queue = append(m.queue[:insertIndex], *song)
+	m.queue = append(m.queue, tail...)
+
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
+
+	if msg.SetAsCurrent {
+		newIdx := insertIndex
+		if newIdx >= len(m.queue) {
+			newIdx = len(m.queue) - 1
+		}
+		m.queueIndex = newIdx
+		return m, m.playQueueIndex(newIdx, false)
+	}
+
+	m.syncNextSong()
+	return m, nil
+}
+
+func (m model) handleRemoveTrackRequest(msg integration.RemoveTrackRequestMsg) (tea.Model, tea.Cmd) {
+	removeIndex := -1
+	for i, tid := range m.queueTrackIDs {
+		if tid == msg.TrackID {
+			removeIndex = i
+			break
+		}
+	}
+	if removeIndex < 0 || removeIndex >= len(m.queue) {
+		return m, nil
+	}
+
+	if removeIndex == m.queueIndex {
+		return m, nil
+	}
+
+	m.queue = append(m.queue[:removeIndex], m.queue[removeIndex+1:]...)
+
+	if removeIndex < m.queueIndex {
+		m.queueIndex--
+	}
+
+	m = m.generateTrackIDs()
+	m.syncTrackListToDBus()
+
+	m.syncNextSong()
+	return m, nil
+}
+
+func (m model) handleGoToRequest(msg integration.GoToRequestMsg) (tea.Model, tea.Cmd) {
+	for i, tid := range m.queueTrackIDs {
+		if tid == msg.TrackID {
+			return m, m.playQueueIndex(i, false)
+		}
+	}
+	return m, nil
+}
+
+func extractSongIDFromURI(uri string) string {
+	if strings.Contains(uri, "id=") {
+		parts := strings.Split(uri, "id=")
+		if len(parts) > 1 {
+			id := strings.Split(parts[1], "&")[0]
+			return id
+		}
+	}
+
+	return uri
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -672,6 +672,7 @@ func footerInformation(m model, width int) string {
 
 	// Middle row
 	var songAlbumArtistInfo string
+	var djStatus string
 	var loopStatus string
 	var volumeStatus string
 
@@ -681,6 +682,11 @@ func footerInformation(m model, width int) string {
 		songAlbumArtistInfo = ""
 	} else {
 		songAlbumArtistInfo = api.SanitizeDisplayString(m.playerStatus.Artist + " - " + m.playerStatus.Album)
+	}
+
+	if m.djEnabled {
+		moodLabel := DjMoodLabels[m.djMood]
+		djStatus = fmt.Sprintf("[DJ: %s]", moodLabel)
 	}
 
 	switch m.loopMode {
@@ -696,16 +702,28 @@ func footerInformation(m model, width int) string {
 		volumeStatus = fmt.Sprintf("[%v%%]", m.playerStatus.Volume)
 	}
 
-	middleRowGap := width - runewidth.StringWidth(songAlbumArtistInfo) - runewidth.StringWidth(loopStatus) - 1 - runewidth.StringWidth(volumeStatus)
+	rightSideWidth := runewidth.StringWidth(djStatus)
+	if djStatus != "" {
+		rightSideWidth++
+	}
+	rightSideWidth += runewidth.StringWidth(loopStatus)
+	if loopStatus != "" {
+		rightSideWidth++
+	}
+	rightSideWidth += runewidth.StringWidth(volumeStatus)
+
+	middleRowGap := width - runewidth.StringWidth(songAlbumArtistInfo) - rightSideWidth
 	if middleRowGap < 0 {
 		middleRowGap = 0
 	}
 
-	truncatedSongAlbumArtistInfo := truncate(songAlbumArtistInfo, width-runewidth.StringWidth(loopStatus)-1-runewidth.StringWidth(volumeStatus))
+	truncatedSongAlbumArtistInfo := truncate(songAlbumArtistInfo, width-rightSideWidth)
 	middleRow = lipgloss.JoinHorizontal(
 		lipgloss.Center,
 		truncatedSongAlbumArtistInfo,
 		strings.Repeat(" ", middleRowGap),
+		djStatus,
+		" ",
 		loopStatus,
 		" ",
 		volumeStatus,
@@ -925,15 +943,22 @@ func mediaPlayerSideSongContent(m model, width int, height int) string {
 
 	// Status Section
 	var notificationStatus string
+	var djStatus string
 	var loopStatus string
 	var volumeStatus string
 
 	var notificationGap int
+	var djGap int
 	var loopGap int
 	var volumeGap int
 
 	if !m.notify {
 		notificationStatus = "[Silent]"
+	}
+
+	if m.djEnabled {
+		moodLabel := DjMoodLabels[m.djMood]
+		djStatus = fmt.Sprintf("[DJ:%s]", moodLabel)
 	}
 
 	switch m.loopMode {
@@ -950,14 +975,18 @@ func mediaPlayerSideSongContent(m model, width int, height int) string {
 	}
 
 	statusAvailableWidth := width - 4 // 2x 2 padding
-	statusWidth := statusAvailableWidth / 3
+	statusWidth := statusAvailableWidth / 4
 
 	notificationGap = (statusWidth - len(notificationStatus)) / 2
+	djGap = (statusWidth - len(djStatus)) / 2
 	loopGap = (statusWidth - len(loopStatus)) / 2
 	volumeGap = (statusWidth - len(volumeStatus)) / 2
 
 	if notificationGap < 0 {
 		notificationGap = 0
+	}
+	if djGap < 0 {
+		djGap = 0
 	}
 	if loopGap < 0 {
 		loopGap = 0
@@ -968,6 +997,7 @@ func mediaPlayerSideSongContent(m model, width int, height int) string {
 
 	statusSection = lipgloss.JoinHorizontal(lipgloss.Center,
 		strings.Repeat(" ", notificationGap)+notificationStatus+strings.Repeat(" ", notificationGap),
+		strings.Repeat(" ", djGap)+djStatus+strings.Repeat(" ", djGap),
 		strings.Repeat(" ", loopGap)+loopStatus+strings.Repeat(" ", loopGap),
 		strings.Repeat(" ", volumeGap)+volumeStatus+strings.Repeat(" ", volumeGap),
 	)
@@ -1232,6 +1262,8 @@ func helpViewContent() string {
 		line(keys(api.AppConfig.Keybinds.Media.VolumeUp), "Volume up"),
 		line(keys(api.AppConfig.Keybinds.Media.VolumeDown), "Volume down"),
 		line(keys(api.AppConfig.Keybinds.Media.ToggleMediaPlayer), "Media Player"),
+		line(keys(api.AppConfig.Keybinds.Media.DjToggle), "DJ mode"),
+		line(keys(api.AppConfig.Keybinds.Media.DjCycleMood), "Cycle DJ mood"),
 	)
 
 	queueKeybinds := section("QUEUE",

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 	defer player.ShutdownPlayer()
 
 	// Init TUI
-	p := tea.NewProgram(ui.InitialModel(), tea.WithAltScreen())
+	p := tea.NewProgram(ui.InitialModel(), tea.WithAltScreen(), tea.WithMouseAllMotion())
 
 	// Start background services
 	instance := integration.Init(p)


### PR DESCRIPTION
Add handling for MouseButtonWheelUp/Down events to scroll through lists 
(main view, sidebar, media player lyrics, popups). Includes enabling 
tea.WithMouseAllMotion() for proper mouse event support.

Also adds a DJ/Radio mode that auto-generates and refills the play queue 
using weighted random selection based on similar songs, rating and mood 
filters (Chill/Energy/Focus). Includes a follow-up fix to update the DJ 
seed on each song change.