### PR TITLE
feat(player): radio/mix from track

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -415,6 +415,20 @@ func SubsonicCreateShare(ids []string) (string, error) {
 
 }
 
+func SubsonicGetSimilarSongs(id string) ([]Song, error) {
+	params := url.Values{
+		"id":    {id},
+		"count": {"50"},
+	}
+
+	data, err := subsonicGET("/getSimilarSongs2", params)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.Response.SimilarSongs.Songs, nil
+}
+
 func SubsonicGetLyrics(ID string) ([]StructuredLyrics, error) {
 	params := url.Values{
 		"id": {ID},

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -199,6 +199,7 @@ type FavoriteKeybinds struct {
 type OtherKeybinds struct {
 	ToggleNotifications []string `toml:"toggle_notifications"`
 	CreateShareLink     []string `toml:"create_share_link"`
+	StartRadio          []string `toml:"start_radio"`
 }
 
 func createDefaultConfig(path string, content []byte, label string, permissions os.FileMode) error {

--- a/internal/api/config.toml
+++ b/internal/api/config.toml
@@ -122,3 +122,4 @@ max_rating = 0 # Exclude songs with a rating less than or equal to this number (
   [keybinds.other]
   toggle_notifications = ['s']
   create_share_link    = ['ctrl+s']
+  start_radio          = ['r']

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -44,6 +44,9 @@ type SubsonicResponse struct {
 		LyricsList struct {
 			StructuredLyrics []StructuredLyrics `json:"structuredLyrics"`
 		} `json:"lyricsList"`
+		SimilarSongs struct {
+			Songs []Song `json:"song"`
+		} `json:"similarSongs2"`
 	} `json:"subsonic-response"`
 }
 

--- a/internal/ui/cmds_api.go
+++ b/internal/ui/cmds_api.go
@@ -206,13 +206,13 @@ func addRatingCmd(ids []string, rating int) tea.Cmd {
 	}
 }
 
-func startRadioCmd(seed api.Song) tea.Cmd {
+func startRadioCmd(seedID string, prepend []api.Song) tea.Cmd {
 	return func() tea.Msg {
-		similar, err := api.SubsonicGetSimilarSongs(seed.ID)
+		similar, err := api.SubsonicGetSimilarSongs(seedID)
 		if err != nil {
 			return errMsg{err}
 		}
-		return radioResultMsg(append([]api.Song{seed}, similar...))
+		return radioResultMsg(append(prepend, similar...))
 	}
 }
 

--- a/internal/ui/cmds_api.go
+++ b/internal/ui/cmds_api.go
@@ -206,6 +206,16 @@ func addRatingCmd(ids []string, rating int) tea.Cmd {
 	}
 }
 
+func startRadioCmd(seed api.Song) tea.Cmd {
+	return func() tea.Msg {
+		similar, err := api.SubsonicGetSimilarSongs(seed.ID)
+		if err != nil {
+			return errMsg{err}
+		}
+		return radioResultMsg(append([]api.Song{seed}, similar...))
+	}
+}
+
 func createMediaShareCmd(ids []string) tea.Cmd {
 	return func() tea.Msg {
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -169,6 +169,8 @@ type getLyricsMsg struct {
 	result []api.StructuredLyrics
 }
 
+type radioResultMsg []api.Song
+
 type errMsg struct {
 	err error
 }

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -58,6 +58,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case getLyricsMsg:
 		return m.handleLyrics(msg)
 
+	case radioResultMsg:
+		return m.handleRadio(msg)
+
 	case playQueueResultMsg:
 		return m.handlePlayQueueResult(msg)
 

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -269,6 +269,10 @@ func (m model) handlesKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, mediaCreateShare(m)
 	}
 
+	if keyMatches(key, api.AppConfig.Keybinds.Other.StartRadio) {
+		return startRadio(m)
+	}
+
 	if keyMatches(key, api.AppConfig.Keybinds.Other.ToggleNotifications) {
 		return toggleNotifications(m), nil
 	}
@@ -1440,6 +1444,30 @@ func mediaCreateShare(m model) tea.Cmd {
 	}
 
 	return nil
+}
+
+func startRadio(m model) (tea.Model, tea.Cmd) {
+	var song api.Song
+
+	switch m.focus {
+	case focusMain:
+		if m.displayMode == displaySongs && m.viewMode == viewList && len(m.songs) > 0 {
+			song = m.songs[m.cursorMain]
+		} else if m.viewMode == viewQueue && len(m.queue) > 0 {
+			song = m.queue[m.cursorMain]
+		}
+	case focusSong:
+		if len(m.queue) > 0 {
+			song = m.queue[m.queueIndex]
+		}
+	}
+
+	if song.ID == "" {
+		return m, nil
+	}
+
+	m.loading = true
+	return m, startRadioCmd(song)
 }
 
 func toggleNotifications(m model) model {

--- a/internal/ui/update_keys.go
+++ b/internal/ui/update_keys.go
@@ -1447,27 +1447,46 @@ func mediaCreateShare(m model) tea.Cmd {
 }
 
 func startRadio(m model) (tea.Model, tea.Cmd) {
-	var song api.Song
+	var seedID string
+	var prepend []api.Song
+
+	seedSong := func(song api.Song) {
+		seedID = song.ID
+		prepend = []api.Song{song}
+	}
 
 	switch m.focus {
 	case focusMain:
-		if m.displayMode == displaySongs && m.viewMode == viewList && len(m.songs) > 0 {
-			song = m.songs[m.cursorMain]
-		} else if m.viewMode == viewQueue && len(m.queue) > 0 {
-			song = m.queue[m.cursorMain]
+		if m.viewMode == viewQueue && len(m.queue) > 0 {
+			seedSong(m.queue[m.cursorMain])
+			break
+		}
+		switch m.displayMode {
+		case displaySongs:
+			if m.viewMode == viewList && len(m.songs) > 0 {
+				seedSong(m.songs[m.cursorMain])
+			}
+		case displayAlbums:
+			if len(m.albums) > 0 {
+				seedID = m.albums[m.cursorMain].ID
+			}
+		case displayArtist:
+			if len(m.artists) > 0 {
+				seedID = m.artists[m.cursorMain].ID
+			}
 		}
 	case focusSong:
 		if len(m.queue) > 0 {
-			song = m.queue[m.queueIndex]
+			seedSong(m.queue[m.queueIndex])
 		}
 	}
 
-	if song.ID == "" {
+	if seedID == "" {
 		return m, nil
 	}
 
 	m.loading = true
-	return m, startRadioCmd(song)
+	return m, startRadioCmd(seedID, prepend)
 }
 
 func toggleNotifications(m model) model {

--- a/internal/ui/update_messages.go
+++ b/internal/ui/update_messages.go
@@ -511,6 +511,13 @@ func (m model) handleCreateShare(msg createShareMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m model) handleRadio(msg radioResultMsg) (tea.Model, tea.Cmd) {
+	m.queue = msg
+	m.queueIndex = 0
+	m.loading = false
+	return m, m.playQueueIndex(0, false)
+}
+
 func (m model) handleLyrics(msg getLyricsMsg) (tea.Model, tea.Cmd) {
 	m.songLyrics = msg.result
 	return m, nil

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1234,6 +1234,7 @@ func helpViewContent() string {
 		line(keys(api.AppConfig.Keybinds.Media.VolumeUp), "Volume up"),
 		line(keys(api.AppConfig.Keybinds.Media.VolumeDown), "Volume down"),
 		line(keys(api.AppConfig.Keybinds.Media.ToggleMediaPlayer), "Media Player"),
+		line(keys(api.AppConfig.Keybinds.Other.StartRadio), "Start radio"),
 	)
 
 	queueKeybinds := section("QUEUE",


### PR DESCRIPTION
Added radio mix feature by calling /getSimilarSongs2 endpoint.

Addresses #142.

Lets you start radio for a song / album / artist by pressing 'r'. Uses song / album / artist id based on what menu you're in. 

It's a very simple method by just making one call to the /getSimilarSongs2 when you press the keybind, maybe we could explore doing incremental queue building, and all the other fancy stuff Tempus has. It's what I mostly use, and it feels like it has this feature down best so far, imo. My current solution works more than good enough for me, though.